### PR TITLE
Fix AI prompt task filtering

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -214,7 +214,8 @@ module.exports = NodeHelper.create({
   },
 
   buildPromptFromTasks() {
-    const relevantTasks = tasks.filter(t => t.done === true && t.deleted === true).map(t => ({
+    // Collect completed tasks that haven't been deleted
+    const relevantTasks = tasks.filter(t => t.done === true && !t.deleted).map(t => ({
       name:        t.name,
       assignedTo:  t.assignedTo,
       date:        t.date,


### PR DESCRIPTION
## Summary
- allow AI prompt generation to consider completed tasks even if they haven't been deleted

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848a89f5d2083249249c89b43285647