### PR TITLE
Add calendar view for tasks

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -160,3 +160,13 @@ h1, h2 {
     top: 25px;
   }
 }
+
+/* Calendar */
+#taskCalendar table {
+  table-layout: fixed;
+}
+#taskCalendar td {
+  height: 100px;
+  vertical-align: top;
+  font-size: 0.8rem;
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -62,6 +62,14 @@
                 </span>
               </div>
               <div class="card-body">
+                <div class="d-flex justify-content-end mb-2">
+                  <button class="btn btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#calendarCollapse">
+                    <i class="bi bi-calendar3"></i>
+                  </button>
+                </div>
+                <div id="calendarCollapse" class="collapse mb-3">
+                  <div id="taskCalendar"></div>
+                </div>
                 <form id="taskForm" class="row gy-2 gx-2 align-items-center mb-3" novalidate>
                   <div class="col-sm">
                     <input type="text" id="taskName" class="form-control" placeholder="Task name…" required />


### PR DESCRIPTION
## Summary
- allow toggling a calendar under the Tasks section
- style the calendar table
- render undone tasks in a monthly calendar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849e663188483248480c1b6932969ee