### PR TITLE
Improve admin calendar view

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -136,6 +136,14 @@ h1, h2 {
   opacity: .6;
 }
 
+/* Task date color adjustment */
+.task-date {
+  color: #6c757d;
+}
+[data-theme="dark"] .task-date {
+  color: var(--text);
+}
+
 /* Oversized checkboxes */
 .form-check-input {
   appearance: auto;


### PR DESCRIPTION
## Summary
- enhance calendar with week/month navigation and toggle
- adjust task date style for dark mode

## Testing
- `npm test` *(fails: Missing script)*
- `node -c public/admin.js`


------
https://chatgpt.com/codex/tasks/task_b_684a8165f9e083299f0429a516f2d424