### PR TITLE
Fix admin calendar translation and layout

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -6,6 +6,7 @@
   --card-bg: #fff;
   --shadow: 0 6px 18px rgba(0,0,0,.05);
   --list-hover: rgba(0,0,0,.03);
+  --border: #dee2e6;
 }
 
 [data-theme="dark"] {
@@ -16,6 +17,7 @@
   --card-bg: #1e1e1e;
   --shadow: 0 6px 18px rgba(0,0,0,.4);
   --list-hover: rgba(255,255,255,.03);
+  --border: #444;
 }
 
 /* Global */
@@ -42,23 +44,28 @@ h1, h2 {
 }
 
 /* Theme toggle */
-.theme-switch {
+
+/* Container for theme toggle and language select */
+.top-controls {
   position: absolute;
   top: 30px;
   right: 22px;
   z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.theme-switch {
+  position: static;
 }
 
 /* Språkval dropdown placerad under theme-switch */
 .language-select {
-  position: absolute;
-  top: 65px;
-  right: 22px;
-  width: 30px;
+  width: 60px;
   max-width: 80px;
-  z-index: 1100;
   font-weight: 600;
-  font-size: 0.5rem;
+  font-size: 0.8rem;
   padding: 2px 6px;
   border: 1px solid var(--text);
   border-radius: 4px;
@@ -157,24 +164,32 @@ h1, h2 {
 
 /* Responsive adjustments */
 @media (max-width: 576px) {
-  .language-select {
-    width: 70px;
-    font-size: 0.8rem;
-    top: 55px;
+  .top-controls {
+    top: 25px;
     right: 15px;
   }
-  .theme-switch {
-    right: 50px;
-    top: 25px;
+  .language-select {
+    width: 70px;
   }
 }
 
 /* Calendar */
 #taskCalendar table {
   table-layout: fixed;
+  background: var(--card-bg);
+  color: var(--text);
+}
+#taskCalendar th,
+#taskCalendar td {
+  border-color: var(--border);
 }
 #taskCalendar td {
   height: 100px;
   vertical-align: top;
   font-size: 0.8rem;
+}
+
+/* Ensure calendar header text is white in dark mode */
+[data-theme="dark"] #calTitle {
+  color: #fff;
 }

--- a/public/admin.html
+++ b/public/admin.html
@@ -13,11 +13,14 @@
 <body>
   <div class="container py-4 flex-grow-1 position-relative">
 
-    <div class="form-check form-switch theme-switch">
-      <input class="form-check-input" type="checkbox" id="themeToggle" />
-      <label class="form-check-label small" for="themeToggle">
-        <i class="bi" id="themeIcon"></i>
-      </label>
+    <div class="top-controls">
+      <div class="form-check form-switch theme-switch">
+        <input class="form-check-input" type="checkbox" id="themeToggle" />
+        <label class="form-check-label small" for="themeToggle">
+          <i class="bi" id="themeIcon"></i>
+        </label>
+      </div>
+      <!-- language selector inserted via JS -->
     </div>
 
     <div class="hero mb-4">

--- a/public/admin.js
+++ b/public/admin.js
@@ -35,6 +35,8 @@ const LANGUAGES = {
       weekendTasksCompleted: "Weekend Tasks Completed",
       oldestOpenTaskAge: "Oldest Open Task Age (days)"
     },
+    weekLabel: "Week",
+    monthLabel: "Month",
     footer: "Built with Bootstrap & Chart.js • MMM-Chores by Pierre Gode"
   },
   sv: {
@@ -73,6 +75,8 @@ const LANGUAGES = {
       weekendTasksCompleted: "Helguppgifter slutförda",
       oldestOpenTaskAge: "Äldsta öppna uppgiftens ålder (dagar)"
     },
+    weekLabel: "Vecka",
+    monthLabel: "Månad",
     footer: "Byggt med Bootstrap & Chart.js • MMM-Chores av Pierre Gode"
   },
   fr: {
@@ -111,6 +115,8 @@ const LANGUAGES = {
       weekendTasksCompleted: "Tâches du week-end terminées",
       oldestOpenTaskAge: "Âge de la plus vieille tâche ouverte (jours)"
     },
+    weekLabel: "Semaine",
+    monthLabel: "Mois",
     footer: "Construit avec Bootstrap & Chart.js • MMM-Chores par Pierre Gode"
   },
   es: {
@@ -149,6 +155,8 @@ const LANGUAGES = {
       weekendTasksCompleted: "Tareas completadas el fin de semana",
       oldestOpenTaskAge: "Edad de la tarea abierta más antigua (días)"
     },
+    weekLabel: "Semana",
+    monthLabel: "Mes",
     footer: "Construido con Bootstrap y Chart.js • MMM-Chores por Pierre Gode"
   },
   de: {
@@ -187,6 +195,8 @@ const LANGUAGES = {
       weekendTasksCompleted: "Wochenendaufgaben abgeschlossen",
       oldestOpenTaskAge: "Alter der ältesten offenen Aufgabe (Tage)"
     },
+    weekLabel: "Woche",
+    monthLabel: "Monat",
     footer: "Erstellt mit Bootstrap & Chart.js • MMM-Chores von Pierre Gode"
   },
   it: {
@@ -225,6 +235,8 @@ const LANGUAGES = {
       weekendTasksCompleted: "Compiti completati nel weekend",
       oldestOpenTaskAge: "Età del compito aperto più vecchio (giorni)"
     },
+    weekLabel: "Settimana",
+    monthLabel: "Mese",
     footer: "Realizzato con Bootstrap & Chart.js • MMM-Chores di Pierre Gode"
   },
   nl: {
@@ -263,6 +275,8 @@ const LANGUAGES = {
       weekendTasksCompleted: "Weekendtaken voltooid",
       oldestOpenTaskAge: "Leeftijd van oudste open taak (dagen)"
     },
+    weekLabel: "Week",
+    monthLabel: "Maand",
     footer: "Gemaakt met Bootstrap & Chart.js • MMM-Chores door Pierre Gode"
   },
   pl: {
@@ -301,6 +315,8 @@ const LANGUAGES = {
       weekendTasksCompleted: "Wykonane zadania weekendowe",
       oldestOpenTaskAge: "Wiek najstarszego otwartego zadania (dni)"
     },
+    weekLabel: "Tydzień",
+    monthLabel: "Miesiąc",
     footer: "Zbudowane z Bootstrap i Chart.js • MMM-Chores przez Pierre Gode"
   },
   zh: {
@@ -339,6 +355,8 @@ const LANGUAGES = {
       weekendTasksCompleted: "周末完成的任务",
       oldestOpenTaskAge: "最旧未完成任务时间 (天)"
     },
+    weekLabel: "周",
+    monthLabel: "月",
     footer: "由 Bootstrap 和 Chart.js 构建 • MMM-Chores 由 Pierre Gode 创建"
   },
   ar: {
@@ -377,6 +395,8 @@ const LANGUAGES = {
       weekendTasksCompleted: "المهام المكتملة في عطلة نهاية الأسبوع",
       oldestOpenTaskAge: "عمر أقدم مهمة مفتوحة (أيام)"
     },
+    weekLabel: "أسبوع",
+    monthLabel: "شهر",
     footer: "تم الإنشاء باستخدام Bootstrap و Chart.js • MMM-Chores بواسطة Pierre Gode"
   }
 };
@@ -389,6 +409,8 @@ let chartIdCounter = 0;
 let boardTitleMap = {};
 let calendarView = 'week';
 let calendarDate = new Date();
+let localizedMonths = [];
+let localizedWeekdays = [];
 
 // ==========================
 // API: Hämta språk från backend
@@ -437,6 +459,14 @@ function setLanguage(lang) {
 
   const t = LANGUAGES[lang];
 
+  localizedMonths = Array.from({ length: 12 }, (_, i) =>
+    new Date(2000, i).toLocaleDateString(lang, { month: "short" })
+  );
+  localizedWeekdays = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(2021, 5, 7 + i); // Monday based
+    return d.toLocaleDateString(lang, { weekday: "short" });
+  });
+
   document.querySelector(".hero h1").textContent = t.title;
   document.querySelector(".hero small").textContent = t.subtitle;
 
@@ -484,6 +514,7 @@ function setLanguage(lang) {
   updateBoardTitleMap();
   renderPeople();
   renderTasks();
+  renderCalendar();
 
   Object.entries(chartInstances).forEach(([id, chart]) => {
     const cardHeaderSpan = document.querySelector(`#${id}`).closest(".card").querySelector(".card-header span");
@@ -679,7 +710,7 @@ function renderCalendar() {
     tasksByDate[t.date].push(t);
   });
 
-  const weekdays = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"];
+  const weekdays = localizedWeekdays.length ? localizedWeekdays : ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"];
   const pad = n => String(n).padStart(2, '0');
 
   let html = `
@@ -687,7 +718,7 @@ function renderCalendar() {
       <button class="btn btn-sm btn-outline-secondary" id="calPrev">&lt;</button>
       <span id="calTitle" class="fw-bold"></span>
       <div class="d-flex gap-2">
-        <button class="btn btn-sm btn-outline-secondary" id="calToggle">${calendarView === 'week' ? 'Month' : 'Week'}</button>
+        <button class="btn btn-sm btn-outline-secondary" id="calToggle">${calendarView === 'week' ? LANGUAGES[currentLang].monthLabel : LANGUAGES[currentLang].weekLabel}</button>
         <button class="btn btn-sm btn-outline-secondary" id="calNext">&gt;</button>
       </div>
     </div>`;
@@ -740,10 +771,10 @@ function renderCalendar() {
 
   const titleEl = document.getElementById('calTitle');
   if (calendarView === 'month') {
-    const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+    const months = localizedMonths.length ? localizedMonths : ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
     titleEl.textContent = `${months[calendarDate.getMonth()]} ${calendarDate.getFullYear()}`;
   } else {
-    titleEl.textContent = `Week ${getWeekNumber(calendarDate)} ${calendarDate.getFullYear()}`;
+    titleEl.textContent = `${LANGUAGES[currentLang].weekLabel} ${getWeekNumber(calendarDate)} ${calendarDate.getFullYear()}`;
   }
 
   document.getElementById('calPrev').onclick = () => {
@@ -1152,9 +1183,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     await saveUserLanguage(newLang);
   });
 
-  const themeSwitch = document.querySelector(".theme-switch");
-  if (themeSwitch) {
-    themeSwitch.parentNode.insertBefore(selector, themeSwitch.nextSibling);
+  const controls = document.querySelector(".top-controls");
+  if (controls) {
+    controls.appendChild(selector);
   } else {
     document.body.appendChild(selector);
   }


### PR DESCRIPTION
## Summary
- tweak color variables and calendar table to respect dark mode
- move theme toggle and language dropdown into a shared top-controls container
- translate calendar months/weeks via browser locale
- ensure language selector attaches to the new container
- make calendar header text white in dark mode

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_684be092d31883249e6a34e33cec2847