### PR TITLE
Add textMirrorSize and useAI config options

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -4,7 +4,9 @@ Module.register("MMM-Chores", {
     adminPort: 5003,
     showDays: 1,
     showPast: false,
-    dateFormatting: "yyyy-mm-dd" // Standardformat, kan ändras i config
+    dateFormatting: "yyyy-mm-dd", // Standardformat, kan ändras i config
+    textMirrorSize: "small",     // small, medium or large
+    useAI: true                   // hide AI features when false
   },
 
   start() {
@@ -120,7 +122,7 @@ Module.register("MMM-Chores", {
 
     if (visible.length === 0) {
       const emptyEl = document.createElement("div");
-      emptyEl.className = "small dimmed";
+      emptyEl.className = `${this.config.textMirrorSize} dimmed`;
       emptyEl.innerHTML = "No tasks to show 🎉";
       wrapper.appendChild(emptyEl);
       return wrapper;
@@ -131,7 +133,7 @@ Module.register("MMM-Chores", {
 
     visible.forEach(task => {
       const li = document.createElement("li");
-      li.className = "small";
+      li.className = this.config.textMirrorSize;
 
       const cb = document.createElement("input");
       cb.type = "checkbox";

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ in /MagicMirror/config/config.js
     updateInterval: 60 * 1000,
     adminPort: 5003,
     openaiApiKey: "your-openApi-key-here",
+    useAI: true,        // hide AI features when false
     showDays: 3,       // show tasks from today and the next 2 days (total 3 days)
     showPast: true,    // also show unfinished tasks from past days
+    textMirrorSize: "small", // small, medium or large
     dateFormatting: "MM-DD"  // Date format pattern to display task dates.
                              // Use tokens like 'yyyy', 'mm', 'dd'.
                              // Set to "" to hide the date completely.

--- a/node_helper.js
+++ b/node_helper.js
@@ -29,7 +29,9 @@ let people = [];
 let analyticsBoards = [];
 
 let settings = {
-  language: "en"
+  language: "en",
+  dateFormatting: "yyyy-mm-dd",
+  useAI: true
 };
 
 function loadData() {
@@ -39,7 +41,7 @@ function loadData() {
       tasks            = j.tasks            || [];
       people           = j.people           || [];
       analyticsBoards  = j.analyticsBoards  || [];
-      settings         = j.settings         || { language: "en", dateFormatting: "yyyy-mm-dd" };
+      settings         = j.settings         || { language: "en", dateFormatting: "yyyy-mm-dd", useAI: true };
 
       Log.log(`MMM-Chores: Loaded ${tasks.length} tasks, ${people.length} people, ${analyticsBoards.length} analytics boards, language: ${settings.language}`);
     } catch (e) {
@@ -80,7 +82,8 @@ module.exports = NodeHelper.create({
       settings = {
         ...settings,
         language:       payload.language       ?? settings.language,
-        dateFormatting: payload.dateFormatting ?? settings.dateFormatting
+        dateFormatting: payload.dateFormatting ?? settings.dateFormatting,
+        useAI:          payload.useAI          ?? settings.useAI
       };
       saveData();
       this.initServer(payload.adminPort);

--- a/public/admin.js
+++ b/public/admin.js
@@ -433,17 +433,17 @@ let localizedMonths = [];
 let localizedWeekdays = [];
 
 // ==========================
-// API: Hämta språk från backend
+// API: Hämta inställningar från backend
 // ==========================
-async function fetchUserLanguage() {
+async function fetchUserSettings() {
   try {
     const res = await fetch('/api/settings');
     if (!res.ok) throw new Error('Failed fetching user settings');
     const data = await res.json();
-    return data.language && LANGUAGES[data.language] ? data.language : null;
+    return data;
   } catch (e) {
-    console.warn('Could not fetch user language:', e);
-    return null;
+    console.warn('Could not fetch user settings:', e);
+    return {};
   }
 }
 
@@ -1185,9 +1185,9 @@ function setIcon(theme) {
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
-  const savedLang = await fetchUserLanguage();
-  if (savedLang) {
-    currentLang = savedLang;
+  const userSettings = await fetchUserSettings();
+  if (userSettings.language && LANGUAGES[userSettings.language]) {
+    currentLang = userSettings.language;
   } else {
     currentLang = localStorage.getItem("mmm-chores-lang") || 'en';
   }
@@ -1212,6 +1212,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     controls.appendChild(selector);
   } else {
     document.body.appendChild(selector);
+  }
+
+  const aiButton = document.getElementById("btnAiGenerate");
+  if (aiButton && userSettings.useAI === false) {
+    aiButton.style.display = "none";
   }
 
   setLanguage(currentLang);


### PR DESCRIPTION
## Summary
- allow setting text size on the mirror via `textMirrorSize`
- permit disabling AI features by `useAI`
- hide AI button in admin portal when AI is disabled
- expose new setting to admin frontend
- document new configuration options

## Testing
- `node --check MMM-Chores.js`
- `node --check node_helper.js`
- `node --check public/admin.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c90dff330832499f3226679515dd1