### PR TITLE
Fix: remove global level header

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -144,14 +144,8 @@ Module.register("MMM-Chores", {
   getDom() {
     const wrapper = document.createElement("div");
 
-    const header = document.createElement("div");
-    header.className = "bright large";
-    if (this.levelInfo) {
-      header.innerHTML = `Level ${this.levelInfo.level} – ${this.levelInfo.title}`;
-    } else {
-      header.innerHTML = "";
-    }
-    wrapper.appendChild(header);
+    // Remove the large header showing the global level. Levels are displayed
+    // next to each person's name instead.
 
     if (this.titleChangeMessage) {
       const note = document.createElement("div");


### PR DESCRIPTION
## Summary
- remove the top level header so only per-user level badges appear

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68590d7e9c44832488c6533407f56599