### PR TITLE
Hide level badges when leveling disabled

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -189,7 +189,10 @@ Module.register("MMM-Chores", {
         assignedEl.className = "xsmall dimmed";
         assignedEl.style.marginLeft = "6px";
         let html = ` — ${p ? p.name : ""}`;
-        if (p && p.level) {
+        const lvlEnabled = !(
+          this.config.leveling && this.config.leveling.enabled === false
+        );
+        if (lvlEnabled && p && p.level) {
           html += ` <span class="lvl-badge">lvl${p.level}</span>`;
         }
         assignedEl.innerHTML = html;

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ in /MagicMirror/config/config.js
 },
 ```
 
+When `leveling.enabled` is set to `false`, the MagicMirror display hides the
+`lvlX` badges next to assigned names.
+
 ### Level titles
 
 For level **N** (1 ≤ N ≤ 100), the module chooses a title based on the ten-level


### PR DESCRIPTION
## Summary
- hide level badges on the MagicMirror display if the `leveling.enabled` config option is `false`
- document level badge hiding behaviour in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68590fb8fd888324899163e67f6b4d6f