### PR TITLE
Fix level text color in dark mode

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -232,5 +232,5 @@ h1, h2 {
 
 /* Ensure level text remains visible on dark backgrounds */
 [data-theme="dark"] #peopleList small {
-  color: #fff;
+  color: #fff !important;
 }


### PR DESCRIPTION
## Summary
- keep level info readable when dark theme enabled

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68591b7bed4c8324a38f526cad3cd099