### PR TITLE
Add per-user level rewards

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -24,7 +24,8 @@ Module.register("MMM-Chores", {
       "Grandmaster",
       "Legend",
       "Mythic"
-    ]
+    ],
+    customLevelTitles: {}
   },
 
   start() {

--- a/README.md
+++ b/README.md
@@ -103,6 +103,32 @@ still uses the first title and 11 uses the second.
 Specify your own titles by providing a `levelTitles` array with exactly ten
 strings in the configuration. If omitted, the defaults shown above are used.
 
+### Custom titles per person
+
+You can override the global rewards for an individual by using the
+`customLevelTitles` object. The keys are the person's name and the value should
+be an array of ten titles.
+
+```js
+customLevelTitles: {
+  Pierre: [
+    "10 euro game giftcard",
+    "Movie Night Voucher",
+    "Dinner at Favorite Restaurant",
+    "Weekend Brunch Voucher",
+    "Gadget Accessory (e.g. Headphones)",
+    "Spa or Relaxation Package",
+    "Adventure Experience Voucher",
+    "Weekend trip",
+    "Adventureland",
+    "Travel destination"
+  ]
+}
+```
+
+Any person not listed in `customLevelTitles` falls back to the global
+`levelTitles` array or the defaults.
+
 ### Per-person levels
 
 Each person earns experience separately. Their current level and title are stored

--- a/node_helper.js
+++ b/node_helper.js
@@ -93,23 +93,37 @@ function computeLevel(config, personId = null) {
   return lvl;
 }
 
-function getTitle(config, level) {
-  const arr = Array.isArray(config.levelTitles) && config.levelTitles.length === 10
-    ? config.levelTitles
-    : DEFAULT_TITLES;
+function getTitle(config, level, person = null) {
+  let arr;
+  if (
+    person &&
+    config.customLevelTitles &&
+    Array.isArray(config.customLevelTitles[person.name]) &&
+    config.customLevelTitles[person.name].length === 10
+  ) {
+    arr = config.customLevelTitles[person.name];
+  } else if (
+    Array.isArray(config.levelTitles) &&
+    config.levelTitles.length === 10
+  ) {
+    arr = config.levelTitles;
+  } else {
+    arr = DEFAULT_TITLES;
+  }
   const idx = Math.floor((level - 1) / 10);
   return arr[idx] || arr[arr.length - 1];
 }
 
-function getLevelInfo(config, personId = null) {
+function getLevelInfo(config, person = null) {
+  const personId = person ? person.id : null;
   const level = computeLevel(config, personId);
-  const title = getTitle(config, level);
+  const title = getTitle(config, level, person);
   return { level, title };
 }
 
 function updatePeopleLevels(config) {
   people = people.map(p => {
-    const info = getLevelInfo(config, p.id);
+    const info = getLevelInfo(config, p);
     return { ...p, level: info.level, title: info.title };
   });
 }
@@ -381,8 +395,9 @@ module.exports = NodeHelper.create({
       // person's ID ensures the level is based on their own completed chores
       // (which will be zero for a new person) rather than the global stats.
       const id = Date.now();
-      const info = getLevelInfo(self.config || {}, id);
-      const newPerson = { id, name, level: info.level, title: info.title };
+      const newPersonBase = { id, name };
+      const info = getLevelInfo(self.config || {}, newPersonBase);
+      const newPerson = { ...newPersonBase, level: info.level, title: info.title };
 
       people.push(newPerson);
       saveData();


### PR DESCRIPTION
## Summary
- support customLevelTitles config to override rewards for specific people
- update node helper to use per-person titles
- document how to set customLevelTitles

## Testing
- `node --check MMM-Chores.js`
- `node --check node_helper.js`

------
https://chatgpt.com/codex/tasks/task_e_685a2583894883249477d75ad1bf0e62