### PR TITLE
Hide levels when leveling is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ levels could also be rewards
 
 
 
-When `leveling.enabled` is set to `false`, the MagicMirror display hides the
-`lvlX` badges next to assigned names.
+When `leveling.enabled` is set to `false`, both the MagicMirror display and the
+admin portal hide any level badges and reward titles.
 
 ### Level titles
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -44,7 +44,8 @@ const DEFAULT_TITLES = [
 let settings = {
   language: "en",
   dateFormatting: "yyyy-mm-dd",
-  useAI: true
+  useAI: true,
+  levelingEnabled: true
 };
 
 function loadData() {
@@ -54,7 +55,8 @@ function loadData() {
       tasks            = j.tasks            || [];
       people           = j.people           || [];
       analyticsBoards  = j.analyticsBoards  || [];
-      settings         = j.settings         || { language: "en", dateFormatting: "yyyy-mm-dd", useAI: true };
+      settings         = j.settings         || { language: "en", dateFormatting: "yyyy-mm-dd", useAI: true, levelingEnabled: true };
+      if (settings.levelingEnabled === undefined) settings.levelingEnabled = true;
 
       updatePeopleLevels({});
 
@@ -166,7 +168,8 @@ module.exports = NodeHelper.create({
         ...settings,
         language:       payload.language       ?? settings.language,
         dateFormatting: payload.dateFormatting ?? settings.dateFormatting,
-        useAI:          payload.useAI          ?? settings.useAI
+        useAI:          payload.useAI          ?? settings.useAI,
+        levelingEnabled: payload.leveling?.enabled !== false
       };
       saveData();
       this.initServer(payload.adminPort);

--- a/public/admin.js
+++ b/public/admin.js
@@ -10,6 +10,7 @@ let calendarView = 'week';
 let calendarDate = new Date();
 let localizedMonths = [];
 let localizedWeekdays = [];
+let levelingEnabled = true;
 
 // ==========================
 // API: Hämta inställningar från backend
@@ -170,7 +171,7 @@ function renderPeople() {
     li.className = "list-group-item d-flex justify-content-between align-items-center";
     const info = document.createElement("span");
     info.textContent = person.name;
-    if (person.level) {
+    if (levelingEnabled && person.level) {
       const small = document.createElement("small");
       small.className = "ms-2 text-muted";
       const titlePart = person.title ? ` - ${person.title}` : "";
@@ -788,6 +789,9 @@ function setIcon(theme) {
 
 document.addEventListener("DOMContentLoaded", async () => {
   const userSettings = await fetchUserSettings();
+  if (typeof userSettings.levelingEnabled === "boolean") {
+    levelingEnabled = userSettings.levelingEnabled;
+  }
   if (userSettings.language && LANGUAGES[userSettings.language]) {
     currentLang = userSettings.language;
   } else {


### PR DESCRIPTION
## Summary
- persist `levelingEnabled` in settings
- provide the flag to the admin portal
- hide level info in the admin page when disabled
- document the behavior in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a2b7831d48324976dbbe71d734473