### PR TITLE
Add analytics support on mirror

### DIFF
--- a/MMM-Chores.css
+++ b/MMM-Chores.css
@@ -49,3 +49,17 @@
   opacity: 0.7;
   font-size: 0.8em;
 }
+
+/* Analytics charts */
+.MMM-Chores .analytics-wrapper {
+  margin-top: 10px;
+}
+
+.MMM-Chores .analytics-card {
+  margin-bottom: 10px;
+}
+
+.MMM-Chores .analytics-chart {
+  width: 100%;
+  height: 150px;
+}

--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -1,3 +1,14 @@
+const BOARD_TITLES = {
+  weekly: "Tasks Completed Per Week",
+  weekdays: "Busiest Weekdays",
+  perPerson: "Chores Per Person",
+  taskmaster: "Taskmaster This Month",
+  lazyLegends: "Lazy Legends",
+  speedDemons: "Speed Demons",
+  weekendWarriors: "Weekend Warriors",
+  slacker9000: "Slacker Detector 9000"
+};
+
 Module.register("MMM-Chores", {
   defaults: {
     updateInterval: 60 * 1000,
@@ -7,6 +18,8 @@ Module.register("MMM-Chores", {
     dateFormatting: "yyyy-mm-dd", // Standardformat, kan ändras i config
     textMirrorSize: "small",     // small, medium or large
     useAI: true,                  // hide AI features when false
+    showAnalyticsOnMirror: false, // display analytics cards on the mirror
+    analyticsCards: [],           // array of analytics card types
     leveling: {
       enabled: true,
       yearsToMaxLevel: 3,
@@ -32,12 +45,22 @@ Module.register("MMM-Chores", {
     this.tasks = [];
     this.people = [];
     this.levelInfo = null;
+    this.chartInstances = {};
     this.sendSocketNotification("INIT_SERVER", this.config);
     this.scheduleUpdate();
   },
 
   getStyles() {
     return ["MMM-Chores.css"];
+  },
+
+  getScripts() {
+    if (this.config.showAnalyticsOnMirror) {
+      return [
+        "https://cdn.jsdelivr.net/npm/chart.js@4.3.0/dist/chart.umd.min.js"
+      ];
+    }
+    return [];
   },
 
   scheduleUpdate() {
@@ -142,6 +165,143 @@ Module.register("MMM-Chores", {
     return result;
   },
 
+  buildChartData(type) {
+    const filteredTasks = fn => this.tasks.filter(t => !(t.deleted && !t.done) && fn(t));
+    let data = { labels: [], datasets: [] };
+    let options = { scales: { y: { beginAtZero: true } } };
+    let chartType = "bar";
+
+    switch (type) {
+      case "weekly": {
+        const today = new Date();
+        const labels = [];
+        const counts = [];
+        for (let i = 3; i >= 0; i--) {
+          const d = new Date(today);
+          d.setDate(today.getDate() - i * 7);
+          labels.push(d.toISOString().split("T")[0]);
+          const c = filteredTasks(t => {
+            const td = new Date(t.date);
+            return t.done && ((today - td) / 86400000) >= i * 7 && ((today - td) / 86400000) < (i + 1) * 7;
+          }).length;
+          counts.push(c);
+        }
+        data = { labels, datasets: [{ label: "Completed Tasks", data: counts, backgroundColor: "rgba(75,192,192,0.5)" }] };
+        break;
+      }
+      case "weekdays": {
+        chartType = "pie";
+        const labels = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"];
+        const arr = [0,0,0,0,0,0,0];
+        filteredTasks(t => true).forEach(t => {
+          const idx = (new Date(t.date).getDay() + 6) % 7;
+          arr[idx]++;
+        });
+        data = {
+          labels,
+          datasets: [{ data: arr, backgroundColor: ["#FF6384","#36A2EB","#FFCE56","#4BC0C0","#9966FF","#FF9F40","#C9CBCF"] }]
+        };
+        options = {};
+        break;
+      }
+      case "perPerson": {
+        const labels = this.people.map(p => p.name);
+        const counts = this.people.map(p => filteredTasks(t => t.assignedTo === p.id).length);
+        data = { labels, datasets: [{ label: "Unfinished Tasks", data: counts, backgroundColor: "rgba(153,102,255,0.5)" }] };
+        break;
+      }
+      case "taskmaster": {
+        const now = new Date();
+        const labels = this.people.map(p => p.name);
+        const counts = this.people.map(p => this.tasks.filter(t => {
+          const d = new Date(t.date);
+          return t.done && d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear() && t.assignedTo === p.id;
+        }).length);
+        data = { labels, datasets: [{ label: BOARD_TITLES.taskmaster, data: counts, backgroundColor: "rgba(255,159,64,0.5)" }] };
+        break;
+      }
+      case "lazyLegends": {
+        const labels = this.people.map(p => p.name);
+        const counts = this.people.map(p => filteredTasks(t => t.assignedTo === p.id && !t.done).length);
+        data = { labels, datasets: [{ label: BOARD_TITLES.lazyLegends, data: counts, backgroundColor: "rgba(255,99,132,0.5)" }] };
+        break;
+      }
+      case "speedDemons": {
+        const labels = this.people.map(p => p.name);
+        const avgDays = this.people.map(p => {
+          const times = filteredTasks(t => t.assignedTo === p.id && t.done && t.finished && t.assignedDate).map(t => {
+            const dDone = new Date(t.finished);
+            const dAssigned = new Date(t.assignedDate);
+            return (dDone - dAssigned) / (1000*60*60*24);
+          });
+          if (times.length === 0) return 0;
+          return times.reduce((a,b) => a+b, 0) / times.length;
+        });
+        data = { labels, datasets: [{ label: BOARD_TITLES.speedDemons, data: avgDays, backgroundColor: "rgba(54,162,235,0.5)" }] };
+        break;
+      }
+      case "weekendWarriors": {
+        const labels = this.people.map(p => p.name);
+        const counts = this.people.map(p => filteredTasks(t => {
+          if (!t.done || t.assignedTo !== p.id) return false;
+          const d = new Date(t.date);
+          return d.getDay() === 0 || d.getDay() === 6;
+        }).length);
+        data = { labels, datasets: [{ label: BOARD_TITLES.weekendWarriors, data: counts, backgroundColor: "rgba(255,206,86,0.5)" }] };
+        break;
+      }
+      case "slacker9000": {
+        const labels = this.people.map(p => p.name);
+        const ages = this.people.map(p => {
+          const open = filteredTasks(t => t.assignedTo === p.id && !t.done && t.assignedDate);
+          if (open.length === 0) return 0;
+          const now = new Date();
+          return Math.max(...open.map(t => (now - new Date(t.assignedDate)) / (1000*60*60*24)));
+        });
+        data = { labels, datasets: [{ label: BOARD_TITLES.slacker9000, data: ages, backgroundColor: "rgba(153,102,255,0.5)" }] };
+        break;
+      }
+      default:
+        data = { labels: [], datasets: [] };
+        break;
+    }
+
+    return { chartType, data, options };
+  },
+
+  renderCharts() {
+    if (!this.config.showAnalyticsOnMirror || typeof Chart === "undefined") return;
+
+    const types = this.config.analyticsCards;
+    const currentIds = [];
+
+    types.forEach((type, idx) => {
+      const id = `chart-${idx}`;
+      currentIds.push(id);
+      const canvas = document.getElementById(id);
+      if (!canvas) return;
+      const ctx = canvas.getContext("2d");
+      const { chartType, data, options } = this.buildChartData(type);
+      const existing = this.chartInstances[id];
+      if (existing) {
+        existing.config.type = chartType;
+        existing.data = data;
+        existing.options = options;
+        existing.update();
+      } else {
+        this.chartInstances[id] = new Chart(ctx, { type: chartType, data, options });
+      }
+    });
+
+    // destroy charts that are no longer configured
+    Object.keys(this.chartInstances).forEach(id => {
+      if (!currentIds.includes(id)) {
+        this.chartInstances[id].destroy();
+        delete this.chartInstances[id];
+      }
+    });
+  },
+
   getDom() {
     const wrapper = document.createElement("div");
 
@@ -204,6 +364,28 @@ Module.register("MMM-Chores", {
     });
 
     wrapper.appendChild(ul);
+
+    if (this.config.showAnalyticsOnMirror && this.config.analyticsCards.length) {
+      const charts = document.createElement("div");
+      charts.className = "analytics-wrapper";
+      this.config.analyticsCards.forEach((type, idx) => {
+        const card = document.createElement("div");
+        card.className = "analytics-card";
+        const title = document.createElement("div");
+        title.className = "small bright";
+        title.innerHTML = BOARD_TITLES[type] || type;
+        const canvas = document.createElement("canvas");
+        const id = `chart-${idx}`;
+        canvas.id = id;
+        canvas.className = "analytics-chart";
+        card.appendChild(title);
+        card.appendChild(canvas);
+        charts.appendChild(card);
+      });
+      wrapper.appendChild(charts);
+      setTimeout(() => this.renderCharts(), 0);
+    }
+
     return wrapper;
   }
 });

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ in /MagicMirror/config/config.js
     adminPort: 5003,
     openaiApiKey: "your-openApi-key-here",
     useAI: true,        // hide AI features when false
+    showAnalyticsOnMirror: false, // show analytics charts on the mirror
+    analyticsCards: ["speedDemons"], // analytics board types to display
     showDays: 3,       // show tasks from today and the next 2 days (total 3 days)
     showPast: true,    // also show unfinished tasks from past days
     textMirrorSize: "small", // small, medium or large
@@ -72,7 +74,10 @@ in /MagicMirror/config/config.js
 },
 ```
 
-levels could also be rewards 
+Available analytics card types are: `weekly`, `weekdays`, `perPerson`,
+`taskmaster`, `lazyLegends`, `speedDemons`, `weekendWarriors`, and `slacker9000`.
+
+levels could also be rewards
 ```js
     levelTitles: [            // titles for every 10 levels
       "10 euro game giftcard",


### PR DESCRIPTION
## Summary
- add chart titles and new config options
- render analytics charts on the mirror using Chart.js
- update stylesheet for analytics canvas
- document analytics options in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866c8a76af48324bedcfeb31540ada9