### PR TITLE
Sync analytics boards on mirror

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -23,7 +23,7 @@ Module.register("MMM-Chores", {
     textMirrorSize: "small",     // small, medium or large
     useAI: true,                  // hide AI features when false
     showAnalyticsOnMirror: false, // display analytics cards on the mirror
-    analyticsCards: [],           // array of analytics card types
+    analyticsCards: [],           // board types selected in the admin UI
     leveling: {
       enabled: true,
       yearsToMaxLevel: 3,
@@ -87,6 +87,12 @@ Module.register("MMM-Chores", {
     if (notification === "SETTINGS_UPDATE") {
       Object.assign(this.config, payload);
       this.updateDom();
+    }
+    if (notification === "ANALYTICS_UPDATE") {
+      if (Array.isArray(payload)) {
+        this.config.analyticsCards = payload;
+        this.updateDom();
+      }
     }
     if (notification === "LEVEL_INFO") {
       const prevTitle = this.levelInfo ? this.levelInfo.title : null;

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ in /MagicMirror/config/config.js
     updateInterval: 60 * 1000,
     adminPort: 5003,
     showAnalyticsOnMirror: false, // show analytics charts on the mirror
-    analyticsCards: ["speedDemons"], // analytics board types to display
     openaiApiKey: "your-openApi-key-here",
     useAI: true,        // hide AI features when false
     showDays: 3,       // show tasks from today and the next 2 days (total 3 days)
@@ -76,10 +75,12 @@ in /MagicMirror/config/config.js
 },
 ```
 
-Available analytics card types are: `weekly`, `weekdays`, `perPerson`,
-`perPersonFinished`, `perPersonFinishedWeek`, `perPersonUnfinished`,
-`perPersonUnfinishedWeek`, `taskmaster`, `lazyLegends`, `speedDemons`,
-`weekendWarriors`, and `slacker9000`.
+Analytics boards are selected from the admin interface when
+`showAnalyticsOnMirror` is enabled. Available card types are:
+`weekly`, `weekdays`, `perPerson`, `perPersonFinished`,
+`perPersonFinishedWeek`, `perPersonUnfinished`, `perPersonUnfinishedWeek`,
+`taskmaster`, `lazyLegends`, `speedDemons`, `weekendWarriors`, and
+`slacker9000`.
 
 levels could also be rewards
 ```js


### PR DESCRIPTION
## Summary
- update MMM-Chores module to listen for `ANALYTICS_UPDATE`
- remove analytics board config from docs since boards sync automatically

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b77d533f88324a8f39caacb0c7b1b