### PR TITLE
Fix display of deleted tasks

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -371,8 +371,8 @@ Module.register("MMM-Chores", {
       wrapper.appendChild(note);
     }
 
-    // Filtrerar bort raderade tasks
-    const visible = this.tasks.filter(t => !(t.deleted && !t.done) && this.shouldShowTask(t));
+    // Filter out all deleted tasks completely from the mirror
+    const visible = this.tasks.filter(t => !t.deleted && this.shouldShowTask(t));
 
     if (visible.length === 0) {
       const emptyEl = document.createElement("div");


### PR DESCRIPTION
## Summary
- ensure deleted tasks never display on the mirror

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b82d5a5408324b2582cd57759af05