### PR TITLE
Disable periodic refresh with analytics

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -69,6 +69,12 @@ Module.register("MMM-Chores", {
   },
 
   scheduleUpdate() {
+    if (this.config.showAnalyticsOnMirror) {
+      // Avoid refreshing the entire DOM while analytics charts are visible to
+      // prevent a flashing effect. Updates instead come from socket
+      // notifications when data changes.
+      return;
+    }
     setInterval(() => this.updateDom(), this.config.updateInterval);
   },
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ in /MagicMirror/config/config.js
     updateInterval: 60 * 1000,
     adminPort: 5003,
     showAnalyticsOnMirror: false, // show analytics charts on the mirror
+    // When analytics are shown, the module skips the periodic refresh to avoid
+    // the charts flashing on the mirror. The display updates whenever data
+    // changes instead.
     openaiApiKey: "your-openApi-key-here",
     useAI: true,        // hide AI features when false
     showDays: 3,       // show tasks from today and the next 2 days (total 3 days)
@@ -76,7 +79,8 @@ in /MagicMirror/config/config.js
 ```
 
 Analytics boards are selected from the admin interface when
-`showAnalyticsOnMirror` is enabled. Available card types are:
+`showAnalyticsOnMirror` is enabled. Enabling analytics disables the
+scheduled DOM refresh to prevent flickering. Available card types are:
 `weekly`, `weekdays`, `perPerson`, `perPersonFinished`,
 `perPersonFinishedWeek`, `perPersonUnfinished`, `perPersonUnfinishedWeek`,
 `taskmaster`, `lazyLegends`, `speedDemons`, `weekendWarriors`, and


### PR DESCRIPTION
## Summary
- prevent scheduleUpdate when analytics are shown to stop flashing
- document the behaviour in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b875d51588324821e65a2afe3ff08