### PR TITLE
Add task drag-and-drop ordering

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -489,6 +489,22 @@ module.exports = NodeHelper.create({
       res.json({ success: true });
     });
 
+    // Reorder tasks
+    app.put("/api/tasks/reorder", (req, res) => {
+      const ids = req.body;
+      if (!Array.isArray(ids)) {
+        return res.status(400).json({ error: "Expected an array of task ids" });
+      }
+      const idSet = new Set(ids);
+      const map = new Map();
+      tasks.forEach(t => map.set(t.id, t));
+      const reordered = ids.map(id => map.get(id)).filter(Boolean);
+      tasks = reordered.concat(tasks.filter(t => !idSet.has(t.id)));
+      saveData();
+      broadcastTasks(self);
+      res.json({ success: true });
+    });
+
     app.get("/api/analyticsBoards", (req, res) => res.json(analyticsBoards));
     app.post("/api/analyticsBoards", (req, res) => {
       const newBoards = req.body;

--- a/public/admin.css
+++ b/public/admin.css
@@ -187,6 +187,14 @@ h1, h2 {
   border: 1px solid var(--text);
 }
 
+/* Drag handle */
+.drag-handle {
+  cursor: grab;
+}
+.drag-handle:active {
+  cursor: grabbing;
+}
+
 /* Responsive adjustments */
 @media (max-width: 576px) {
   .top-controls {


### PR DESCRIPTION
## Summary
- enable reordering of tasks by dragging
- style drag handle in admin UI
- persist task order server-side

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bb12aefb88324a350e31c4428298c