### PR TITLE
Fix task list reordering in admin portal

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -195,6 +195,14 @@ h1, h2 {
   cursor: grabbing;
 }
 
+/* SortableJS states */
+.sortable-chosen {
+  background-color: rgba(0,0,0,0.05);
+}
+.sortable-ghost {
+  opacity: 0.5;
+}
+
 /* Responsive adjustments */
 @media (max-width: 576px) {
   .top-controls {

--- a/public/admin.html
+++ b/public/admin.html
@@ -135,6 +135,7 @@
   </footer>
 
   <script src="lang.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
   <script src="admin.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/public/admin.js
+++ b/public/admin.js
@@ -11,7 +11,7 @@ let calendarDate = new Date();
 let localizedMonths = [];
 let localizedWeekdays = [];
 let levelingEnabled = true;
-let draggedTaskId = null;
+let taskSortable = null;
 
 // ==========================
 // API: Hämta inställningar från backend
@@ -191,6 +191,7 @@ function renderPeople() {
     li.appendChild(btn);
     list.appendChild(li);
   }
+
 }
 
 function renderTasks() {
@@ -208,6 +209,7 @@ function renderTasks() {
   for (const task of tasksCache.filter(t => !t.deleted)) {
     const li = document.createElement("li");
     li.className = "list-group-item d-flex justify-content-between align-items-center";
+    li.dataset.id = task.id;
 
     const left = document.createElement("div");
     left.className = "d-flex align-items-center";
@@ -290,27 +292,7 @@ function renderTasks() {
     const dragBtn = document.createElement("button");
     dragBtn.className = "btn btn-sm btn-outline-secondary drag-handle me-1";
     dragBtn.innerHTML = '<i class="bi bi-list"></i>';
-    dragBtn.draggable = true;
-    dragBtn.addEventListener("dragstart", e => {
-      draggedTaskId = task.id;
-      e.dataTransfer.effectAllowed = "move";
-    });
-    dragBtn.addEventListener("dragend", () => {
-      draggedTaskId = null;
-    });
 
-    li.addEventListener("dragover", e => {
-      if (draggedTaskId !== null) e.preventDefault();
-    });
-    li.addEventListener("drop", e => {
-      e.preventDefault();
-      const from = tasksCache.findIndex(t => t.id === draggedTaskId);
-      const to = tasksCache.findIndex(t => t.id === task.id);
-      if (from === -1 || to === -1 || from === to) return;
-      tasksCache.splice(to, 0, tasksCache.splice(from, 1)[0]);
-      saveTaskOrder();
-      renderTasks();
-    });
 
     if (!task.done) {
       const edit = document.createElement("button");
@@ -336,6 +318,22 @@ function renderTasks() {
 
     list.appendChild(li);
   }
+
+  if (taskSortable) {
+    taskSortable.destroy();
+  }
+  taskSortable = new Sortable(list, {
+    handle: '.drag-handle',
+    animation: 150,
+    onEnd: async (evt) => {
+      const visible = tasksCache.filter(t => !t.deleted);
+      const moved = visible.splice(evt.oldIndex, 1)[0];
+      visible.splice(evt.newIndex, 0, moved);
+      let i = 0;
+      tasksCache = tasksCache.map(t => t.deleted ? t : visible[i++]);
+      await saveTaskOrder();
+    }
+  });
 }
 
 function getWeekNumber(d) {


### PR DESCRIPTION
## Summary
- add Sortable.js for smooth drag and drop
- style chosen/ghost states for list item dragging
- initialize Sortable in the task list renderer

## Testing
- `node --check public/admin.js`
- `node --check MMM-Chores.js`
- `node --check node_helper.js`


------
https://chatgpt.com/codex/tasks/task_e_686bb337785883248196f7847c307717