### PR TITLE
Fix drag reorder persistence

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -195,6 +195,14 @@ h1, h2 {
   cursor: grabbing;
 }
 
+/* SortableJS states */
+.sortable-chosen {
+  background-color: rgba(0,0,0,0.05);
+}
+.sortable-ghost {
+  opacity: 0.5;
+}
+
 /* Responsive adjustments */
 @media (max-width: 576px) {
   .top-controls {

--- a/public/admin.html
+++ b/public/admin.html
@@ -135,6 +135,7 @@
   </footer>
 
   <script src="lang.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
   <script src="admin.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- ensure tasks are ordered by `order` field on load and broadcast
- store order for new tasks and recurring tasks
- update reorder endpoint to update `order` values
- refresh client cache with new order after dragging

## Testing
- `node --check public/admin.js`
- `node --check MMM-Chores.js`
- `node --check node_helper.js`


------
https://chatgpt.com/codex/tasks/task_e_686bb337785883248196f7847c307717