### PR TITLE
Fix task order persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 It provides an admin interface where you can add, edit, and delete tasks. You can also set due dates and assign tasks to different persons. The module displays the tasks on your MagicMirror, allowing you to keep track of your household chores at a glance.
 
 The data is stored in `data.json` to make the data persistent between restarts.
-Task order is also saved so any manual reordering in the admin UI will survive
-page refreshes and module restarts.
+Task order is also saved (deleted tasks are ignored) so any manual reordering in
+the admin UI will survive page refreshes and module restarts.
 
 *Update 2025-07-07: Analytics boards can now be displayed on the mirror
 


### PR DESCRIPTION
## Summary
- preserve order for non-deleted tasks only
- make sure order persists after refresh/restart
- sync order between admin and mirror

## Testing
- `node --check node_helper.js`
- `node --check public/admin.js`
- `node --check MMM-Chores.js`


------
https://chatgpt.com/codex/tasks/task_e_686bbe7cd3608324a62875e08bd342f2