### PR TITLE
Fix task order persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 
 It provides an admin interface where you can add, edit, and delete tasks. You can also set due dates and assign tasks to different persons. The module displays the tasks on your MagicMirror, allowing you to keep track of your household chores at a glance.
 
-The data is stored in `data.json` to make the data persistent between restarts.
-Task order is also saved (deleted tasks are ignored) so any manual reordering in
-the admin UI will survive page refreshes and module restarts.
+The data is stored in `data.json` so it persists across restarts.
+Use the drag handle ("burger" icon) to reorder tasks in the admin UI. The
+updated order is saved to `data.json` and automatically reloaded, so it
+survives page refreshes and restarts.
 
 *Update 2025-07-07: Analytics boards can now be displayed on the mirror
 

--- a/public/admin.js
+++ b/public/admin.js
@@ -542,6 +542,7 @@ async function saveTaskOrder() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(ids)
   });
+  await fetchTasks();
 }
 
 // ==========================


### PR DESCRIPTION
## Summary
- reload the task list from the server after dragging tasks in admin UI
- clarify in README that reordered tasks persist

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bc3c91a74832494a0184fb498315d