### PR TITLE
Enable task order persistence via drag-and-drop

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -137,6 +137,36 @@
   <script src="lang.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
   <script src="admin.js"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const list = document.getElementById("taskList");
+      if (!list) return;
+
+      Sortable.create(list, {
+        handle: ".drag-handle",
+        animation: 150,
+        onEnd: function () {
+          const ids = Array.from(list.children)
+            .map(li => parseInt(li.dataset.id))
+            .filter(id => !isNaN(id));
+
+          fetch("/api/tasks/reorder", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(ids)
+          })
+            .then(res => {
+              if (!res.ok) throw new Error("Reorder failed");
+              window.location.reload();
+            })
+            .catch(e => {
+              console.error(e);
+              alert("Could not save new task order");
+            });
+        }
+      });
+    });
+  </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -11,7 +11,6 @@ let calendarDate = new Date();
 let localizedMonths = [];
 let localizedWeekdays = [];
 let levelingEnabled = true;
-let taskSortable = null;
 
 // ==========================
 // API: Hämta inställningar från backend
@@ -324,29 +323,7 @@ function renderTasks() {
     list.appendChild(li);
   }
 
-  if (taskSortable) {
-    taskSortable.destroy();
-  }
-  taskSortable = new Sortable(list, {
-    handle: '.drag-handle',
-    animation: 150,
-    onEnd: async (evt) => {
-      const visible = tasksCache.filter(t => !t.deleted);
-      const moved = visible.splice(evt.oldIndex, 1)[0];
-      visible.splice(evt.newIndex, 0, moved);
-      let i = 0;
-      tasksCache = tasksCache.map(t => t.deleted ? t : visible[i++]);
-      let order = 0;
-      tasksCache.forEach(t => {
-        if (t.deleted) {
-          delete t.order;
-        } else {
-          t.order = order++;
-        }
-      });
-      await saveTaskOrder();
-    }
-  });
+  // Dragging is handled separately in admin.html
 }
 
 function getWeekNumber(d) {


### PR DESCRIPTION
## Summary
- hook SortableJS up directly in the admin portal
- remove old Sortable logic from `admin.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bcc8fb1108324a20e721ba5634d3c