### PR TITLE
Fix drag-and-drop task ordering

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -336,15 +336,12 @@ function renderTasks() {
       visible.splice(evt.newIndex, 0, moved);
       let i = 0;
       tasksCache = tasksCache.map(t => t.deleted ? t : visible[i++]);
-      let order = 0;
-      tasksCache.forEach(t => {
-        if (t.deleted) {
-          delete t.order;
-        } else {
-          t.order = order++;
-        }
+      const ids = tasksCache.filter(t => !t.deleted).map(t => t.id);
+      await fetch('/api/tasks/reorder', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(ids)
       });
-      await saveTaskOrder();
     }
   });
 }
@@ -535,15 +532,6 @@ async function deleteTask(id) {
   await fetchTasks();
 }
 
-async function saveTaskOrder() {
-  const ids = tasksCache.filter(t => !t.deleted).map(t => t.id);
-  await fetch('/api/tasks/reorder', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(ids)
-  });
-  await fetchTasks();
-}
 
 // ==========================
 // Analytics Board Persistence


### PR DESCRIPTION
## Summary
- restore SortableJS logic inside `admin.js`
- remove unused inline script in admin page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bcc8fb1108324a20e721ba5634d3c