### PR TITLE
Add settings page to admin portal

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -22,6 +22,7 @@ Module.register("MMM-Chores", {
     dateFormatting: "yyyy-mm-dd", // Standardformat, kan ändras i config
     textMirrorSize: "small",     // small, medium or large
     useAI: true,                  // hide AI features when false
+    openaiApiKey: "",
     showAnalyticsOnMirror: false, // display analytics cards on the mirror
     analyticsCards: [],           // board types selected in the admin UI
     leveling: {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ npm install
 ```
 
 ## Configuration
-in /MagicMirror/config/config.js
+Most settings are now editable in the admin portal under the **Settings** tab.
+Add the module to `config.js` like so:
 ```js
 {
   module: "MMM-Chores",
@@ -46,14 +47,7 @@ in /MagicMirror/config/config.js
   config: {
     updateInterval: 60 * 1000,
     adminPort: 5003,
-    showAnalyticsOnMirror: false, // show analytics charts on the mirror
-    openaiApiKey: "your-openApi-key-here",
-    useAI: true,        // hide AI features when false
-    showPast: true,    // show unfinished tasks from past days
-    textMirrorSize: "small", // small, medium or large
-    dateFormatting: "MM-DD",  // Date format pattern to display task dates.
-                              // Use tokens like 'yyyy', 'mm', 'dd'.
-                              // Set to "" to hide the date completely.
+    // other options can be set in the admin portal
     leveling: {               // optional leveling system
       enabled: true,   // enable or disable leveling system
       yearsToMaxLevel: 3,

--- a/public/admin.html
+++ b/public/admin.html
@@ -36,6 +36,9 @@
       <li class="nav-item" role="presentation">
         <button class="nav-link" data-bs-toggle="tab" data-bs-target="#analytics" type="button" id="tabAnalytics">Analytics</button>
       </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#settings" type="button" id="tabSettings">Settings</button>
+      </li>
     </ul>
 
     <div class="tab-content">
@@ -126,6 +129,49 @@
           </select>
         </div>
         <div id="analyticsContainer" class="row g-3"></div>
+      </div>
+
+      <!-- Settings Tab -->
+      <div class="tab-pane fade" id="settings" role="tabpanel">
+        <form id="settingsForm" class="row gy-3">
+          <div class="col-12 col-sm-6">
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" id="settingsShowPast" />
+              <label class="form-check-label" for="settingsShowPast">Show past tasks</label>
+            </div>
+          </div>
+          <div class="col-12 col-sm-6">
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" id="settingsShowAnalytics" />
+              <label class="form-check-label" for="settingsShowAnalytics">Analytics on mirror</label>
+            </div>
+          </div>
+          <div class="col-12 col-sm-6">
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" id="settingsUseAI" />
+              <label class="form-check-label" for="settingsUseAI">Use AI features</label>
+            </div>
+          </div>
+          <div class="col-12 col-sm-6">
+            <label class="form-label" for="settingsTextSize">Mirror text size</label>
+            <select id="settingsTextSize" class="form-select">
+              <option value="small">Small</option>
+              <option value="medium">Medium</option>
+              <option value="large">Large</option>
+            </select>
+          </div>
+          <div class="col-12 col-sm-6">
+            <label class="form-label" for="settingsDateFmt">Date format</label>
+            <input type="text" id="settingsDateFmt" class="form-control" />
+          </div>
+          <div class="col-12 col-sm-6">
+            <label class="form-label" for="settingsOpenAI">OpenAI API Key</label>
+            <input type="password" id="settingsOpenAI" class="form-control" />
+          </div>
+          <div class="col-12">
+            <button class="btn btn-primary" type="submit">Save</button>
+          </div>
+        </form>
       </div>
     </div>
   </div>

--- a/public/admin.js
+++ b/public/admin.js
@@ -44,6 +44,49 @@ async function saveUserLanguage(lang) {
 }
 
 // ==========================
+// Init settings form and save handler
+// ==========================
+function initSettingsForm(settings) {
+  const form = document.getElementById('settingsForm');
+  if (!form) return;
+
+  const showPast = document.getElementById('settingsShowPast');
+  const textSize = document.getElementById('settingsTextSize');
+  const dateFmt = document.getElementById('settingsDateFmt');
+  const openAI = document.getElementById('settingsOpenAI');
+  const useAI = document.getElementById('settingsUseAI');
+  const showAnalytics = document.getElementById('settingsShowAnalytics');
+
+  if (showPast) showPast.checked = !!settings.showPast;
+  if (textSize) textSize.value = settings.textMirrorSize || 'small';
+  if (dateFmt) dateFmt.value = settings.dateFormatting || '';
+  if (openAI) openAI.value = settings.openaiApiKey || '';
+  if (useAI) useAI.checked = settings.useAI !== false;
+  if (showAnalytics) showAnalytics.checked = !!settings.showAnalyticsOnMirror;
+
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const payload = {
+      showPast: showPast.checked,
+      textMirrorSize: textSize.value,
+      dateFormatting: dateFmt.value,
+      openaiApiKey: openAI.value,
+      useAI: useAI.checked,
+      showAnalyticsOnMirror: showAnalytics.checked
+    };
+    try {
+      await fetch('/api/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+    } catch (err) {
+      console.error('Failed saving settings', err);
+    }
+  });
+}
+
+// ==========================
 // Uppdatera boardTitleMap
 // ==========================
 function updateBoardTitleMap() {
@@ -74,6 +117,7 @@ function setLanguage(lang) {
   const tabs = document.querySelectorAll(".nav-link");
   if (tabs[0]) tabs[0].textContent = t.tabs[0];
   if (tabs[1]) tabs[1].textContent = t.tabs[1];
+  if (tabs[2]) tabs[2].textContent = t.tabs[2] || 'Settings';
 
   const peopleHeader = document.getElementById("peopleHeader");
   if (peopleHeader) peopleHeader.textContent = t.peopleTitle;
@@ -944,6 +988,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   if (aiButton && userSettings.useAI === false) {
     aiButton.style.display = "none";
   }
+
+  initSettingsForm(userSettings);
 
   setLanguage(currentLang);
   await fetchPeople();

--- a/public/lang.js
+++ b/public/lang.js
@@ -2,7 +2,7 @@ const LANGUAGES = {
   en: {
     title: "MMM-Chores Admin  ",
     subtitle: "Manage tasks, people & analytics",
-    tabs: ["Dashboard", "Analytics"],
+    tabs: ["Dashboard", "Analytics", "Settings"],
     peopleTitle: "People",
     newPersonPlaceholder: "New person…",
     addPersonBtnTitle: "Add",
@@ -54,7 +54,7 @@ const LANGUAGES = {
   sv: {
     title: "MMM-Chores Admin  ",
     subtitle: "Hantera uppgifter, personer & analys",
-    tabs: ["Dashboard", "Analys"],
+    tabs: ["Dashboard", "Analys", "Inställningar"],
     peopleTitle: "Personer",
     newPersonPlaceholder: "Ny person…",
     addPersonBtnTitle: "Lägg till",
@@ -106,7 +106,7 @@ const LANGUAGES = {
   fr: {
     title: "MMM-Chores Admin  ",
     subtitle: "Gérer les tâches, les personnes et les analyses",
-    tabs: ["Tableau de bord", "Analytique"],
+    tabs: ["Tableau de bord", "Analytique", "Paramètres"],
     peopleTitle: "Personnes",
     newPersonPlaceholder: "Nouvelle personne…",
     addPersonBtnTitle: "Ajouter",
@@ -158,7 +158,7 @@ const LANGUAGES = {
   es: {
     title: "MMM-Chores Admin  ",
     subtitle: "Gestionar tareas, personas y análisis",
-    tabs: ["Panel", "Analítica"],
+    tabs: ["Panel", "Analítica", "Configuración"],
     peopleTitle: "Personas",
     newPersonPlaceholder: "Nueva persona…",
     addPersonBtnTitle: "Agregar",
@@ -210,7 +210,7 @@ const LANGUAGES = {
   de: {
     title: "MMM-Chores Admin  ",
     subtitle: "Aufgaben, Personen & Analysen verwalten",
-    tabs: ["Übersicht", "Analytik"],
+    tabs: ["Übersicht", "Analytik", "Einstellungen"],
     peopleTitle: "Personen",
     newPersonPlaceholder: "Neue Person…",
     addPersonBtnTitle: "Hinzufügen",
@@ -262,7 +262,7 @@ const LANGUAGES = {
   it: {
     title: "MMM-Chores Admin  ",
     subtitle: "Gestisci compiti, persone e analisi",
-    tabs: ["Dashboard", "Analisi"],
+    tabs: ["Dashboard", "Analisi", "Impostazioni"],
     peopleTitle: "Persone",
     newPersonPlaceholder: "Nuova persona…",
     addPersonBtnTitle: "Aggiungi",
@@ -314,7 +314,7 @@ const LANGUAGES = {
   nl: {
     title: "MMM-Chores Admin  ",
     subtitle: "Beheer taken, mensen & analyses",
-    tabs: ["Dashboard", "Analyse"],
+    tabs: ["Dashboard", "Analyse", "Instellingen"],
     peopleTitle: "Mensen",
     newPersonPlaceholder: "Nieuwe persoon…",
     addPersonBtnTitle: "Toevoegen",
@@ -366,7 +366,7 @@ const LANGUAGES = {
   pl: {
     title: "MMM-Chores Admin  ",
     subtitle: "Zarządzaj zadaniami, ludźmi i analizami",
-    tabs: ["Panel", "Analityka"],
+    tabs: ["Panel", "Analityka", "Ustawienia"],
     peopleTitle: "Osoby",
     newPersonPlaceholder: "Nowa osoba…",
     addPersonBtnTitle: "Dodaj",
@@ -418,7 +418,7 @@ const LANGUAGES = {
   zh: {
     title: "MMM-Chores 管理  ",
     subtitle: "管理任务、人员和分析",
-    tabs: ["仪表板", "分析"],
+    tabs: ["仪表板", "分析", "设置"],
     peopleTitle: "人员",
     newPersonPlaceholder: "新人员…",
     addPersonBtnTitle: "添加",
@@ -470,7 +470,7 @@ const LANGUAGES = {
   ar: {
     title: "إدارة MMM-Chores  ",
     subtitle: "إدارة المهام، الأشخاص والتحليلات",
-    tabs: ["لوحة التحكم", "تحليلات"],
+    tabs: ["لوحة التحكم", "تحليلات", "الإعدادات"],
     peopleTitle: "الأشخاص",
     newPersonPlaceholder: "شخص جديد…",
     addPersonBtnTitle: "إضافة",


### PR DESCRIPTION
## Summary
- manage module options through a new Settings tab
- allow editing of AI key, mirror text size and more
- store settings in `data.json` and sync with the module
- document admin-based configuration in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688966d3ffec8324bf4053054ccce372