### PR TITLE
Fix settings closing reload

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -51,6 +51,7 @@ h1, h2 {
   box-shadow: 0 12px 32px rgba(0,0,0,.15);
   backdrop-filter: blur(calc(var(--blur) / 2));
   margin-bottom: 2rem;
+  margin-top: 3rem;
 }
 
 /* Theme toggle */

--- a/public/admin.js
+++ b/public/admin.js
@@ -13,6 +13,8 @@ let localizedWeekdays = [];
 let levelingEnabled = true;
 let taskSortable = null;
 let settingsMode = 'unlocked';
+let settingsChanged = false;
+let settingsSaved = false;
 
 // ==========================
 // API: Hämta inställningar från backend
@@ -73,8 +75,20 @@ function initSettingsForm(settings) {
   if (perWeekInput) perWeekInput.value = settings.leveling?.choresPerWeekEstimate || 4;
   if (maxLevelInput) maxLevelInput.value = settings.leveling?.maxLevel || 100;
 
+  settingsChanged = false;
+  settingsSaved = false;
+
+  const inputs = [showPast, textSize, dateFmt, openAI, useAI, showAnalytics, levelEnable, yearsInput, perWeekInput, maxLevelInput];
+  inputs.forEach(el => {
+    if (el) {
+      el.addEventListener('input', () => { settingsChanged = true; });
+      el.addEventListener('change', () => { settingsChanged = true; });
+    }
+  });
+
   form.addEventListener('submit', async e => {
     e.preventDefault();
+    settingsSaved = true;
     const payload = {
       showPast: showPast.checked,
       textMirrorSize: textSize.value,
@@ -1057,6 +1071,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   const modal = settingsModalEl ? new bootstrap.Modal(settingsModalEl) : null;
   if (settingsBtn && modal) {
     settingsBtn.addEventListener('click', () => {
+      settingsChanged = false;
+      settingsSaved = false;
       if (settingsMode !== 'unlocked') {
         if (lockedMsg) {
           lockedMsg.textContent = LANGUAGES[currentLang].settingsLocked;
@@ -1068,6 +1084,14 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (settingsForm) settingsForm.classList.remove('d-none');
       }
       modal.show();
+    });
+  }
+
+  if (settingsModalEl) {
+    settingsModalEl.addEventListener('hidden.bs.modal', () => {
+      if (!settingsSaved && settingsChanged) {
+        window.location.reload();
+      }
     });
   }
 });


### PR DESCRIPTION
## Summary
- reload page if settings modal closes without saving
- add margin above header on admin page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688977c76478832485ac57d5d33a43c0