### PR TITLE
Replace theme checkbox with button

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -15,11 +15,10 @@
   <div class="container py-4 flex-grow-1 position-relative">
 
     <div class="top-controls">
-      <div class="form-check form-switch theme-switch">
-        <input class="form-check-input" type="checkbox" id="themeToggle" />
-        <label class="form-check-label small" for="themeToggle">
+      <div class="theme-switch">
+        <button class="btn btn-outline-secondary btn-icon" id="themeToggle" title="Toggle theme">
           <i class="bi" id="themeIcon"></i>
-        </label>
+        </button>
       </div>
       <!-- language selector inserted via JS -->
       <button class="btn btn-outline-secondary btn-icon" id="settingsBtn" title="Settings">

--- a/public/admin.js
+++ b/public/admin.js
@@ -990,17 +990,17 @@ function updateAllCharts() {
 }
 
 const root = document.documentElement;
-const themeTgl = document.getElementById("themeToggle");
+const themeBtn = document.getElementById("themeToggle");
 const themeIcon = document.getElementById("themeIcon");
 const STORAGE_KEY = "mmm-chores-theme";
 
 const savedTheme = localStorage.getItem(STORAGE_KEY) || "light";
 root.setAttribute("data-theme", savedTheme);
-themeTgl.checked = savedTheme === "dark";
 setIcon(savedTheme);
 
-themeTgl.addEventListener("change", () => {
-  const theme = themeTgl.checked ? "dark" : "light";
+themeBtn.addEventListener("click", () => {
+  const current = root.getAttribute("data-theme");
+  const theme = current === "dark" ? "light" : "dark";
   root.setAttribute("data-theme", theme);
   localStorage.setItem(STORAGE_KEY, theme);
   setIcon(theme);


### PR DESCRIPTION
## Summary
- switch to a simple button for toggling dark/light mode
- update script to toggle theme via click

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6889796df9fc832481d715c8d66ec28c