### PR TITLE
Stop browser password save prompt

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -143,7 +143,7 @@
         </div>
         <div class="modal-body">
           <div id="settingsLockedMsg" class="text-center my-3 d-none"></div>
-          <form id="settingsForm" class="row gy-3 d-none">
+          <form id="settingsForm" class="row gy-3 d-none" autocomplete="off">
             <div class="col-12 col-sm-6">
               <div class="form-check form-switch">
                 <input class="form-check-input" type="checkbox" id="settingsShowPast" />
@@ -182,7 +182,7 @@
             </div>
             <div class="col-12 col-sm-6">
               <label class="form-label" for="settingsOpenAI">OpenAI API Key</label>
-              <input type="password" id="settingsOpenAI" class="form-control" />
+              <input type="password" id="settingsOpenAI" class="form-control" autocomplete="new-password" />
             </div>
             <div class="col-12 col-sm-6">
               <label class="form-label" for="settingsYears">Years to max level</label>


### PR DESCRIPTION
## Summary
- disable autofill on settings form
- mark OpenAI API key field as a non-password password input

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68897dab84f8832496cedb19191467cf