### PR TITLE
Fix password prompt on settings

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -67,7 +67,14 @@ function initSettingsForm(settings) {
   if (showPast) showPast.checked = !!settings.showPast;
   if (textSize) textSize.value = settings.textMirrorSize || 'small';
   if (dateFmt) dateFmt.value = settings.dateFormatting || '';
-  if (openAI) openAI.value = settings.openaiApiKey || '';
+  if (openAI) {
+    if (settings.openaiApiKey) {
+      openAI.placeholder = '********';
+      openAI.value = '';
+    } else {
+      openAI.value = '';
+    }
+  }
   if (useAI) useAI.checked = settings.useAI !== false;
   if (showAnalytics) showAnalytics.checked = !!settings.showAnalyticsOnMirror;
   if (levelEnable) levelEnable.checked = settings.levelingEnabled !== false;
@@ -103,6 +110,7 @@ function initSettingsForm(settings) {
         maxLevel: parseInt(maxLevelInput.value, 10) || 100
       }
     };
+    if (!payload.openaiApiKey) delete payload.openaiApiKey;
     try {
       const res = await fetch('/api/settings', {
         method: 'PUT',


### PR DESCRIPTION
## Summary
- blank out OpenAI key field when loading settings to avoid autofilled values
- omit openaiApiKey when not changed so browsers don't show the save password prompt

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688983f3995083249f1b98fd199576c1