### PR TITLE
Fix leveling not updating after settings change

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -664,6 +664,9 @@ module.exports = NodeHelper.create({
         }
       });
       saveData();
+      updatePeopleLevels(self.config);
+      self.sendSocketNotification("LEVEL_INFO", getLevelInfo(self.config));
+      self.sendSocketNotification("PEOPLE_UPDATE", people);
       self.sendSocketNotification("SETTINGS_UPDATE", settings);
       res.json({ success: true, settings });
     });


### PR DESCRIPTION
## Summary
- recompute levels when settings are updated

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a99452cf88324b403992009ff5ab3