### PR TITLE
feat: configure OpenAI key via module config

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -47,7 +47,6 @@ let settings = {
   textMirrorSize: "small",
   showPast: false,
   showAnalyticsOnMirror: false,
-  openaiApiKey: "",
   useAI: true,
   levelingEnabled: true,
   leveling: {
@@ -87,7 +86,6 @@ function loadData() {
         textMirrorSize: "small",
         showPast: false,
         showAnalyticsOnMirror: false,
-        openaiApiKey: "",
         useAI: true,
         levelingEnabled: true,
         leveling: {
@@ -96,6 +94,7 @@ function loadData() {
           maxLevel: 100
         }
       };
+      if (settings.openaiApiKey !== undefined) delete settings.openaiApiKey;
       if (settings.levelingEnabled === undefined) settings.levelingEnabled = true;
       if (!settings.leveling) {
         settings.leveling = { yearsToMaxLevel: 3, choresPerWeekEstimate: 4, maxLevel: 100 };
@@ -103,7 +102,6 @@ function loadData() {
       if (settings.textMirrorSize === undefined) settings.textMirrorSize = "small";
       if (settings.showPast === undefined) settings.showPast = false;
       if (settings.showAnalyticsOnMirror === undefined) settings.showAnalyticsOnMirror = false;
-      if (settings.openaiApiKey === undefined) settings.openaiApiKey = "";
       if (settings.useAI === undefined) settings.useAI = true;
       if (!settings.leveling) {
         settings.leveling = { yearsToMaxLevel: 3, choresPerWeekEstimate: 4, maxLevel: 100 };
@@ -257,7 +255,6 @@ module.exports = NodeHelper.create({
         textMirrorSize:       payload.textMirrorSize       ?? settings.textMirrorSize,
         showPast:             payload.showPast             ?? settings.showPast,
         showAnalyticsOnMirror: payload.showAnalyticsOnMirror ?? settings.showAnalyticsOnMirror,
-        openaiApiKey:         payload.openaiApiKey         ?? settings.openaiApiKey,
         useAI:                payload.useAI                ?? settings.useAI,
         levelingEnabled:      payload.leveling?.enabled !== false,
         leveling: {
@@ -640,7 +637,9 @@ module.exports = NodeHelper.create({
     });
 
     app.get("/api/settings", (req, res) => {
-      res.json({ ...settings, leveling: settings.leveling, settings: self.config.settings });
+      const safeSettings = { ...settings };
+      delete safeSettings.openaiApiKey;
+      res.json({ ...safeSettings, leveling: safeSettings.leveling, settings: self.config.settings });
     });
     app.put("/api/settings", (req, res) => {
       const newSettings = req.body;
@@ -652,7 +651,7 @@ module.exports = NodeHelper.create({
         self.config.leveling = { ...self.config.leveling, ...newSettings.leveling };
       }
       Object.entries(newSettings).forEach(([key, val]) => {
-        if (key === "leveling") return;
+        if (key === "leveling" || key === "openaiApiKey") return;
         settings[key] = val;
         if (self.config) {
           if (key === "levelingEnabled") {

--- a/public/admin.html
+++ b/public/admin.html
@@ -181,10 +181,6 @@
               <input type="text" id="settingsDateFmt" class="form-control" />
             </div>
             <div class="col-12 col-sm-6">
-              <label class="form-label" for="settingsOpenAI">OpenAI API Key</label>
-              <input type="password" id="settingsOpenAI" class="form-control" autocomplete="new-password" />
-            </div>
-            <div class="col-12 col-sm-6">
               <label class="form-label" for="settingsYears">Years to max level</label>
               <input type="number" id="settingsYears" class="form-control" />
             </div>

--- a/public/admin.js
+++ b/public/admin.js
@@ -56,7 +56,6 @@ function initSettingsForm(settings) {
   const showPast = document.getElementById('settingsShowPast');
   const textSize = document.getElementById('settingsTextSize');
   const dateFmt = document.getElementById('settingsDateFmt');
-  const openAI = document.getElementById('settingsOpenAI');
   const useAI = document.getElementById('settingsUseAI');
   const showAnalytics = document.getElementById('settingsShowAnalytics');
   const levelEnable = document.getElementById('settingsLevelEnable');
@@ -67,14 +66,6 @@ function initSettingsForm(settings) {
   if (showPast) showPast.checked = !!settings.showPast;
   if (textSize) textSize.value = settings.textMirrorSize || 'small';
   if (dateFmt) dateFmt.value = settings.dateFormatting || '';
-  if (openAI) {
-    if (settings.openaiApiKey) {
-      openAI.placeholder = '********';
-      openAI.value = '';
-    } else {
-      openAI.value = '';
-    }
-  }
   if (useAI) useAI.checked = settings.useAI !== false;
   if (showAnalytics) showAnalytics.checked = !!settings.showAnalyticsOnMirror;
   if (levelEnable) levelEnable.checked = settings.levelingEnabled !== false;
@@ -85,7 +76,7 @@ function initSettingsForm(settings) {
   settingsChanged = false;
   settingsSaved = false;
 
-  const inputs = [showPast, textSize, dateFmt, openAI, useAI, showAnalytics, levelEnable, yearsInput, perWeekInput, maxLevelInput];
+  const inputs = [showPast, textSize, dateFmt, useAI, showAnalytics, levelEnable, yearsInput, perWeekInput, maxLevelInput];
   inputs.forEach(el => {
     if (el) {
       el.addEventListener('input', () => { settingsChanged = true; });
@@ -100,7 +91,6 @@ function initSettingsForm(settings) {
       showPast: showPast.checked,
       textMirrorSize: textSize.value,
       dateFormatting: dateFmt.value,
-      openaiApiKey: openAI.value,
       useAI: useAI.checked,
       showAnalyticsOnMirror: showAnalytics.checked,
       levelingEnabled: levelEnable.checked,
@@ -110,7 +100,6 @@ function initSettingsForm(settings) {
         maxLevel: parseInt(maxLevelInput.value, 10) || 100
       }
     };
-    if (!payload.openaiApiKey) delete payload.openaiApiKey;
     try {
       const res = await fetch('/api/settings', {
         method: 'PUT',


### PR DESCRIPTION
## Summary
- remove OpenAI API key field from admin UI
- ignore API key in settings API and strip any stored key

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689058d79c388324a9524f328b2d9618