### PR TITLE
Add date format options and hide date on admin page

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -178,7 +178,14 @@
             </div>
             <div class="col-12 col-sm-6">
               <label class="form-label" for="settingsDateFmt">Date format</label>
-              <input type="text" id="settingsDateFmt" class="form-control" />
+              <select id="settingsDateFmt" class="form-select">
+                <option value="">Do not show date</option>
+                <option value="yyyy-mm-dd">yyyy-mm-dd</option>
+                <option value="mm-dd">mm-dd</option>
+                <option value="mm-dd-yyyy">mm-dd-yyyy</option>
+                <option value="mm-dd">mm-dd</option>
+                <option value="dd">dd</option>
+              </select>
             </div>
             <div class="col-12 col-sm-6">
               <label class="form-label" for="settingsYears">Years to max level</label>

--- a/public/admin.js
+++ b/public/admin.js
@@ -15,6 +15,7 @@ let taskSortable = null;
 let settingsMode = 'unlocked';
 let settingsChanged = false;
 let settingsSaved = false;
+let dateFormatting = '';
 
 // ==========================
 // API: Hämta inställningar från backend
@@ -255,6 +256,9 @@ async function applySettings(newSettings) {
     const aiButton = document.getElementById('btnAiGenerate');
     if (aiButton) aiButton.style.display = newSettings.useAI === false ? 'none' : '';
   }
+  if (newSettings.dateFormatting !== undefined) {
+    dateFormatting = newSettings.dateFormatting;
+  }
   await fetchPeople();
   await fetchTasks();
 }
@@ -299,6 +303,30 @@ function renderPeople() {
     list.appendChild(li);
   }
 
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return '';
+  const match = dateStr.match(/(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return dateStr;
+  const [, yyyy, mm, dd] = match;
+
+  let fmt =
+    dateFormatting !== undefined && dateFormatting !== null
+      ? dateFormatting
+      : 'yyyy-mm-dd';
+
+  if (fmt === '') return '';
+
+  fmt = fmt.replace(/yyyy/gi, yyyy);
+  fmt = fmt.replace(/mm/gi, mm);
+  fmt = fmt.replace(/dd/gi, dd);
+
+  fmt = fmt.replace(/YYYY/g, yyyy);
+  fmt = fmt.replace(/MM/g, mm);
+  fmt = fmt.replace(/DD/g, dd);
+
+  return fmt;
 }
 
 function renderTasks() {
@@ -351,7 +379,11 @@ function renderTasks() {
     });
 
   const span = document.createElement("span");
-  span.innerHTML = `<strong>${task.name}</strong> <small class="task-date">(${task.date})</small>`;
+  const formatted = formatDate(task.date);
+  span.innerHTML = `<strong>${task.name}</strong>`;
+  if (formatted) {
+    span.innerHTML += ` <small class="task-date">(${formatted})</small>`;
+  }
   if (task.recurring && task.recurring !== "none") {
     const recurText = LANGUAGES[currentLang].taskRecurring[task.recurring] || task.recurring;
     span.innerHTML += ` <span class="badge bg-info text-dark">${recurText}</span>`;
@@ -1022,6 +1054,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   } else {
     currentLang = localStorage.getItem("mmm-chores-lang") || 'en';
   }
+  dateFormatting = userSettings.dateFormatting || '';
 
   const selector = document.createElement("select");
   selector.className = "language-select";


### PR DESCRIPTION
## Summary
- Add date format dropdown with options including ability to hide date
- Format task dates in admin according to selected option and omit when disabled
- Persist date format setting and apply when settings are saved or page loads

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68909c3fe7248324b862b76cbd24de7f