### PR TITLE
Fix past task visibility logic

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -128,15 +128,8 @@ Module.register("MMM-Chores", {
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
     if (diffDays < 0) {
-      if (task.done) {
-        if (task.finished) {
-          const fin = new Date(task.finished);
-          fin.setHours(0, 0, 0, 0);
-          if (fin.getTime() === today.getTime()) return true;
-        }
-        return false;
-      }
-      return showPast;
+      if (!showPast) return false;
+      return !task.done;
     }
     return diffDays < showDays;
   },


### PR DESCRIPTION
## Summary
- Only show past tasks when setting `showPast` is enabled and the task is incomplete
- Hide all past tasks when `showPast` is disabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6890a8433ba48324b758a2ef8a6faaba