### PR TITLE
Hide completed past tasks by default

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -128,15 +128,10 @@ Module.register("MMM-Chores", {
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
     if (diffDays < 0) {
-      if (task.done) {
-        if (task.finished) {
-          const fin = new Date(task.finished);
-          fin.setHours(0, 0, 0, 0);
-          if (fin.getTime() === today.getTime()) return true;
-        }
-        return false;
-      }
-      return showPast;
+      // Task is in the past. Respect the showPast setting and only display
+      // unfinished tasks when enabled. Completed past tasks are always hidden.
+      if (!showPast) return false;
+      return !task.done;
     }
     return diffDays < showDays;
   },

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Use the drag handle ("burger" icon) to reorder tasks in the admin UI. The
 updated order is saved to `data.json` and automatically reloaded, so it
 survives page refreshes and restarts.
 
+The **Show past tasks** setting lets you toggle whether overdue tasks that are
+not yet completed should remain visible on the mirror. Completed past tasks are
+always hidden.
+
 *Update 2025-07-07: Analytics boards can now be displayed on the mirror
 
 ## Screenshots


### PR DESCRIPTION
## Summary
- Only display overdue tasks when the "Show past tasks" setting is enabled and the task is unfinished.
- Document how the "Show past tasks" setting behaves.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890aa325f108324bbc56978454d5b44