### PR TITLE
fix: mirror hides level badges when disabled

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -95,6 +95,10 @@ Module.register("MMM-Chores", {
     }
     if (notification === "SETTINGS_UPDATE") {
       Object.assign(this.config, payload);
+      if (payload.levelingEnabled !== undefined) {
+        this.config.leveling = this.config.leveling || {};
+        this.config.leveling.enabled = payload.levelingEnabled;
+      }
       this.updateDom();
     }
     if (notification === "ANALYTICS_UPDATE") {


### PR DESCRIPTION
## Summary
- ensure socket settings update retains leveling.enabled

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890eacbb9208324942dad7834af4cc1