### PR TITLE
feat: add configurable login with user permissions

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -27,6 +27,8 @@ Module.register("MMM-Chores", {
     pushoverApiKey: "",
     pushoverUser: "",
     pushoverEnabled: false,
+    login: false,
+    users: [],
     showAnalyticsOnMirror: false, // display analytics cards on the mirror
     analyticsCards: [],           // board types selected in the admin UI
     leveling: {

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Add the module to `config.js` like so:
     adminPort: 5003,
     openaiApiKey: "your-openApi-key here",
     pushoverApiKey: "your-pushover-api-key",
+    login: false,
+    users: [
+      { username: "admin", password: "secret", permission: "write" },
+      { username: "viewer", password: "viewer", permission: "read" }
+    ],
     settings: "unlocked", // set a 6 digit pin like "000000" to lock settings popup with a personal pin, change 000000 to any 6 digit password you want, or comment this out to lock settings completly
 // other options can be set in the admin portal
     levelTitles: [
@@ -74,6 +79,8 @@ Add the module to `config.js` like so:
   }
 },
 ```
+
+When `login` is set to `true`, define one or more `users` with `username`, `password` and `permission` (`"read"` or `"write"`). Users with read permission may view all tasks but cannot create, delete or modify them.
 
 levels could also be rewards
 ```js

--- a/public/admin.html
+++ b/public/admin.html
@@ -12,7 +12,23 @@
   <link href="admin.css" rel="stylesheet" />
 </head>
 <body>
-  <div class="container py-4 flex-grow-1 position-relative">
+  <div id="loginContainer" class="container py-5" style="max-width:400px; display:none;">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Login</h5>
+        <div class="mb-3">
+          <input type="text" id="loginUser" class="form-control" placeholder="Username" />
+        </div>
+        <div class="mb-3">
+          <input type="password" id="loginPass" class="form-control" placeholder="Password" />
+        </div>
+        <button id="loginBtn" class="btn btn-primary w-100">Login</button>
+        <div id="loginError" class="text-danger mt-2"></div>
+      </div>
+    </div>
+  </div>
+  <div id="app" style="display:none;">
+    <div class="container py-4 flex-grow-1 position-relative">
 
     <div class="top-controls">
       <div class="theme-switch">
@@ -131,10 +147,9 @@
       </div>
 
     </div>
-  </div>
-
-  <!-- Settings Modal -->
-  <div class="modal fade" id="settingsModal" tabindex="-1">
+    
+    <!-- Settings Modal -->
+    <div class="modal fade" id="settingsModal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content card-shadow">
         <div class="modal-header">
@@ -222,11 +237,10 @@
         </div>
       </div>
     </div>
+    <footer class="text-center py-3 small text-muted" id="footerText">
+      MMM-Chores Built by Pierre Gode
+    </footer>
   </div>
-
-  <footer class="text-center py-3 small text-muted" id="footerText">
-    MMM-Chores Built by Pierre Gode
-  </footer>
 
   <script src="lang.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>


### PR DESCRIPTION
## Summary
- add `login` and `users` config options to enable optional authentication
- secure API routes with session tokens and read/write permissions
- include login screen in admin UI and disable editing for read-only users

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a24b1d3958832482bdc2114866c1f1