### PR TITLE
Add glass-effect login overlay

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -251,3 +251,18 @@ h1, h2 {
 [data-theme="dark"] #peopleList small {
   color: #fff !important;
 }
+
+/* Login overlay */
+#loginContainer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(6px);
+  z-index: 2000;
+}
+#loginContainer .card {
+  width: 320px;
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -12,19 +12,19 @@
   <link href="admin.css" rel="stylesheet" />
 </head>
 <body>
-  <div id="loginContainer" class="container py-5" style="max-width:400px; display:none;">
-    <div class="card">
-      <div class="card-body">
-        <h5 class="card-title">Login</h5>
-        <div class="mb-3">
-          <input type="text" id="loginUser" class="form-control" placeholder="Username" />
-        </div>
-        <div class="mb-3">
-          <input type="password" id="loginPass" class="form-control" placeholder="Password" />
-        </div>
-        <button id="loginBtn" class="btn btn-primary w-100">Login</button>
-        <div id="loginError" class="text-danger mt-2"></div>
+  <div id="loginContainer" class="login-overlay" style="display:none;">
+    <div class="card card-shadow p-4">
+      <h2 class="text-center mb-4">Login</h2>
+      <div class="mb-3">
+        <label for="loginUser" class="form-label">Username</label>
+        <input type="text" id="loginUser" class="form-control" placeholder="Username" />
       </div>
+      <div class="mb-3">
+        <label for="loginPass" class="form-label">Password</label>
+        <input type="password" id="loginPass" class="form-control" placeholder="Password" />
+      </div>
+      <button id="loginBtn" class="btn btn-primary w-100">Login</button>
+      <div id="loginError" class="text-danger mt-2"></div>
     </div>
   </div>
   <div id="app" style="display:none;">

--- a/public/admin.js
+++ b/public/admin.js
@@ -34,12 +34,14 @@ async function checkLogin() {
   const res = await fetch('/api/login', { headers: authHeaders() });
   const data = await res.json();
   if (!data.loginRequired) {
+    if (loginDiv) loginDiv.style.display = 'none';
     if (app) app.style.display = '';
     initApp();
     return;
   }
   if (data.loggedIn) {
     userPermission = data.permission || 'write';
+    if (loginDiv) loginDiv.style.display = 'none';
     if (app) app.style.display = '';
     initApp();
     return;


### PR DESCRIPTION
## Summary
- Display login screen as a centered glass-effect overlay
- Style login overlay with blurred backdrop and responsive width
- Hide login screen when authentication is not required or already satisfied

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2555345788324b51a00877d18377c