### PR TITLE
Allow admin page to load without login

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -561,7 +561,9 @@ module.exports = NodeHelper.create({
 
     app.use((req, res, next) => {
       if (!self.config.login) return next();
-      if (req.path === "/api/login") return next();
+      // Allow the login API and root admin page without authentication so the
+      // login overlay can be displayed in the browser.
+      if (req.path === "/api/login" || req.path === "/") return next();
       const token = req.headers["x-auth-token"];
       const user = sessions[token];
       if (!user) return res.status(401).json({ error: "Unauthorized" });


### PR DESCRIPTION
## Summary
- Allow the admin root page to bypass auth middleware so login overlay shows when enabled

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2612bf2988324b26fbb934bf5174a