### PR TITLE
Remove Pushover user key from admin portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install
 ## Configuration
 Most settings are now editable in the admin portal via the cogwheel **Settings** button.
 An additional option **Enable autoupdate** can pull the latest changes via `git pull` and reload the module automatically and Autoupdates run once per day at **04:00** local time.
-Pushover notifications can also be managed from the admin portal (user key and toggle), while the `pushoverApiKey` must be defined in your MagicMirror `config.js`.
+Pushover notifications can be toggled from the admin portal, while the `pushoverApiKey` and `pushoverUser` must be defined in your MagicMirror `config.js`.
 Add the module to `config.js` like so:
 ```js
 {
@@ -56,6 +56,7 @@ Add the module to `config.js` like so:
     adminPort: 5003,
     openaiApiKey: "your-openApi-key here",
     pushoverApiKey: "your-pushover-api-key",
+    pushoverUser: "your-pushover-user-key",
     login: false,
     users: [
       { username: "admin", password: "secret", permission: "write" },
@@ -155,7 +156,7 @@ Go to http://yourmirrorIP:5003/ #page will be reachable within same network.
 ## Push Notifications
 
 If you wish to use push notifications follow guide below.
-Alternatively, you can use [Pushover](https://pushover.net/) by providing a `pushoverApiKey` in your module config and enabling Pushover with a user key from the admin settings.
+Alternatively, you can use [Pushover](https://pushover.net/) by providing both a `pushoverApiKey` and `pushoverUser` in your module config and enabling Pushover in the admin settings.
 
 ![cert](img/screenshot3_cert.png)
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -69,10 +69,10 @@ function scheduleAutoUpdate() {
 }
 
 function sendPushover(config, settings, message) {
-  if (!config.pushoverApiKey || !settings.pushoverEnabled || !settings.pushoverUser) return;
+  if (!config.pushoverApiKey || !settings.pushoverEnabled || !config.pushoverUser) return;
   const params = new URLSearchParams({
     token: config.pushoverApiKey,
-    user: settings.pushoverUser,
+    user: config.pushoverUser,
     message
   });
   fetchFn("https://api.pushover.net/1/messages.json", {
@@ -108,6 +108,7 @@ function loadData() {
       settings        = j.settings        || {};
       if (settings.openaiApiKey !== undefined) delete settings.openaiApiKey;
       if (settings.pushoverApiKey !== undefined) delete settings.pushoverApiKey;
+      if (settings.pushoverUser !== undefined) delete settings.pushoverUser;
 
       updatePeopleLevels({});
 
@@ -282,7 +283,6 @@ module.exports = NodeHelper.create({
         useAI: settings.useAI ?? payload.useAI,
         autoUpdate: settings.autoUpdate ?? payload.autoUpdate,
         pushoverEnabled: settings.pushoverEnabled ?? payload.pushoverEnabled,
-        pushoverUser: settings.pushoverUser ?? payload.pushoverUser,
         levelingEnabled: settings.levelingEnabled ?? (payload.leveling?.enabled !== false),
         leveling: {
           yearsToMaxLevel: settings.leveling?.yearsToMaxLevel ?? payload.leveling?.yearsToMaxLevel,
@@ -743,6 +743,7 @@ module.exports = NodeHelper.create({
       const safeSettings = { ...settings };
       delete safeSettings.openaiApiKey;
       delete safeSettings.pushoverApiKey;
+      delete safeSettings.pushoverUser;
       res.json({ ...safeSettings, leveling: safeSettings.leveling, settings: self.config.settings });
     });
     app.put("/api/settings", requireWrite, (req, res) => {
@@ -756,7 +757,7 @@ module.exports = NodeHelper.create({
         self.config.leveling = { ...self.config.leveling, ...newSettings.leveling };
       }
       Object.entries(newSettings).forEach(([key, val]) => {
-        if (key === "leveling" || key === "openaiApiKey" || key === "pushoverApiKey") return;
+        if (key === "leveling" || key === "openaiApiKey" || key === "pushoverApiKey" || key === "pushoverUser") return;
         settings[key] = val;
         if (self.config) {
           if (key === "levelingEnabled") {

--- a/public/admin.html
+++ b/public/admin.html
@@ -226,10 +226,6 @@
               <label class="form-label" for="settingsMaxLevel">Max level</label>
               <input type="number" id="settingsMaxLevel" class="form-control" />
             </div>
-            <div class="col-12 col-sm-6">
-              <label class="form-label" for="settingsPushoverUser">Pushover User Key</label>
-              <input type="text" id="settingsPushoverUser" class="form-control" />
-            </div>
             <div class="col-12">
               <button class="btn btn-primary" type="submit" id="settingsSaveBtn">Save</button>
             </div>

--- a/public/admin.js
+++ b/public/admin.js
@@ -118,7 +118,6 @@ function initSettingsForm(settings) {
   const levelEnable = document.getElementById('settingsLevelEnable');
   const autoUpdate = document.getElementById('settingsAutoUpdate');
   const pushoverEnable = document.getElementById('settingsPushoverEnable');
-  const pushoverUser = document.getElementById('settingsPushoverUser');
   const yearsInput = document.getElementById('settingsYears');
   const perWeekInput = document.getElementById('settingsPerWeek');
   const maxLevelInput = document.getElementById('settingsMaxLevel');
@@ -131,7 +130,6 @@ function initSettingsForm(settings) {
   if (levelEnable) levelEnable.checked = settings.levelingEnabled !== false;
   if (autoUpdate) autoUpdate.checked = !!settings.autoUpdate;
   if (pushoverEnable) pushoverEnable.checked = !!settings.pushoverEnabled;
-  if (pushoverUser) pushoverUser.value = settings.pushoverUser || '';
   if (yearsInput) yearsInput.value = settings.leveling?.yearsToMaxLevel || 3;
   if (perWeekInput) perWeekInput.value = settings.leveling?.choresPerWeekEstimate || 4;
   if (maxLevelInput) maxLevelInput.value = settings.leveling?.maxLevel || 100;
@@ -139,7 +137,7 @@ function initSettingsForm(settings) {
   settingsChanged = false;
   settingsSaved = false;
 
-  const inputs = [showPast, textSize, dateFmt, useAI, showAnalytics, levelEnable, autoUpdate, pushoverEnable, pushoverUser, yearsInput, perWeekInput, maxLevelInput];
+  const inputs = [showPast, textSize, dateFmt, useAI, showAnalytics, levelEnable, autoUpdate, pushoverEnable, yearsInput, perWeekInput, maxLevelInput];
   inputs.forEach(el => {
     if (el) {
       el.addEventListener('input', () => { settingsChanged = true; });
@@ -159,7 +157,6 @@ function initSettingsForm(settings) {
       levelingEnabled: levelEnable.checked,
       autoUpdate: autoUpdate.checked,
       pushoverEnabled: pushoverEnable.checked,
-      pushoverUser: pushoverUser.value,
       leveling: {
         yearsToMaxLevel: parseFloat(yearsInput.value) || 3,
         choresPerWeekEstimate: parseFloat(perWeekInput.value) || 4,
@@ -228,8 +225,6 @@ function setLanguage(lang) {
   if (autoUpdateLbl) autoUpdateLbl.textContent = t.autoUpdateLabel || 'Enable autoupdate';
   const pushoverEnableLbl = document.querySelector("label[for='settingsPushoverEnable']");
   if (pushoverEnableLbl) pushoverEnableLbl.textContent = t.pushoverEnabledLabel || 'Enable Pushover';
-  const pushoverUserLbl = document.querySelector("label[for='settingsPushoverUser']");
-  if (pushoverUserLbl) pushoverUserLbl.textContent = t.pushoverUserLabel || 'Pushover User Key';
   const yearsLbl = document.querySelector("label[for='settingsYears']");
   if (yearsLbl) yearsLbl.textContent = t.yearsToMaxLabel;
   const perWeekLbl = document.querySelector("label[for='settingsPerWeek']");

--- a/public/lang.js
+++ b/public/lang.js
@@ -62,8 +62,7 @@ const LANGUAGES = {
     yearsToMaxLabel: "Years to max level",
     choresPerWeekLabel: "Chores per week estimate",
     maxLevelLabel: "Max level",
-    pushoverEnabledLabel: "Enable Pushover",
-    pushoverUserLabel: "Pushover User Key"
+    pushoverEnabledLabel: "Enable Pushover"
   },
   sv: {
     title: "MMM-Chores Admin  ",
@@ -128,8 +127,7 @@ const LANGUAGES = {
     yearsToMaxLabel: "År till maxnivå",
     choresPerWeekLabel: "Sysslor per vecka",
     maxLevelLabel: "Maxnivå",
-    pushoverEnabledLabel: "Aktivera Pushover",
-    pushoverUserLabel: "Pushover User Key"
+    pushoverEnabledLabel: "Aktivera Pushover"
   },
   fr: {
     title: "MMM-Chores Admin  ",
@@ -194,8 +192,7 @@ const LANGUAGES = {
     yearsToMaxLabel: "Années jusqu'au niveau max",
     choresPerWeekLabel: "Corvées par semaine",
     maxLevelLabel: "Niveau maximum",
-    pushoverEnabledLabel: "Activer Pushover",
-    pushoverUserLabel: "Pushover User Key"
+    pushoverEnabledLabel: "Activer Pushover"
   },
   es: {
     title: "MMM-Chores Admin  ",
@@ -260,8 +257,7 @@ const LANGUAGES = {
     yearsToMaxLabel: "Años hasta nivel máximo",
     choresPerWeekLabel: "Tareas por semana",
     maxLevelLabel: "Nivel máximo",
-    pushoverEnabledLabel: "Habilitar Pushover",
-    pushoverUserLabel: "Pushover User Key"
+    pushoverEnabledLabel: "Habilitar Pushover"
   },
   de: {
     title: "MMM-Chores Admin  ",
@@ -326,8 +322,7 @@ const LANGUAGES = {
     yearsToMaxLabel: "Jahre bis Max-Level",
     choresPerWeekLabel: "Aufgaben pro Woche",
     maxLevelLabel: "Max-Level",
-    pushoverEnabledLabel: "Pushover aktivieren",
-    pushoverUserLabel: "Pushover User Key"
+    pushoverEnabledLabel: "Pushover aktivieren"
   },
   it: {
     title: "MMM-Chores Admin  ",
@@ -392,8 +387,7 @@ const LANGUAGES = {
     yearsToMaxLabel: "Anni al livello massimo",
     choresPerWeekLabel: "Compiti per settimana",
     maxLevelLabel: "Livello massimo",
-    pushoverEnabledLabel: "Abilita Pushover",
-    pushoverUserLabel: "Pushover User Key"
+    pushoverEnabledLabel: "Abilita Pushover"
   },
   nl: {
     title: "MMM-Chores Admin  ",
@@ -458,8 +452,7 @@ const LANGUAGES = {
     yearsToMaxLabel: "Jaren tot max level",
     choresPerWeekLabel: "Klussen per week",
     maxLevelLabel: "Max level",
-    pushoverEnabledLabel: "Pushover inschakelen",
-    pushoverUserLabel: "Pushover User Key"
+    pushoverEnabledLabel: "Pushover inschakelen"
   },
   pl: {
     title: "MMM-Chores Admin  ",
@@ -524,8 +517,7 @@ const LANGUAGES = {
     yearsToMaxLabel: "Lata do maks. poziomu",
     choresPerWeekLabel: "Zadania na tydzień",
     maxLevelLabel: "Maks. poziom",
-    pushoverEnabledLabel: "Włącz Pushover",
-    pushoverUserLabel: "Pushover User Key"
+    pushoverEnabledLabel: "Włącz Pushover"
   },
   zh: {
     title: "MMM-Chores 管理  ",
@@ -590,8 +582,7 @@ const LANGUAGES = {
     yearsToMaxLabel: "达到最高等级的年数",
     choresPerWeekLabel: "每周任务数预估",
     maxLevelLabel: "最高等级",
-    pushoverEnabledLabel: "启用 Pushover",
-    pushoverUserLabel: "Pushover User Key"
+    pushoverEnabledLabel: "启用 Pushover"
   },
   ar: {
     title: "إدارة MMM-Chores  ",
@@ -656,7 +647,6 @@ const LANGUAGES = {
     yearsToMaxLabel: "السنوات حتى أعلى مستوى",
     choresPerWeekLabel: "عدد المهام أسبوعيًا",
     maxLevelLabel: "أقصى مستوى",
-    pushoverEnabledLabel: "تفعيل Pushover",
-    pushoverUserLabel: "Pushover User Key"
+    pushoverEnabledLabel: "تفعيل Pushover"
   }
 };

--- a/readmeES.md
+++ b/readmeES.md
@@ -42,7 +42,7 @@ npm install
 ## Configuración
 La mayoría de los ajustes ahora se pueden editar en el portal de administración mediante el botón de engranaje **Settings**.
 Una opción adicional **Enable autoupdate** puede obtener los últimos cambios mediante `git pull` y recargar el módulo automáticamente. Las actualizaciones automáticas se ejecutan una vez al día a las **04:00** hora local.
-Las notificaciones de Pushover también se pueden gestionar desde el portal de administración (clave de usuario y activación), mientras que `pushoverApiKey` debe definirse en tu `config.js` de MagicMirror.
+Las notificaciones de Pushover se pueden activar o desactivar desde el portal de administración, mientras que `pushoverApiKey` y `pushoverUser` deben definirse en tu `config.js` de MagicMirror.
 Añade el módulo a `config.js` así:
 ```js
 {
@@ -54,6 +54,7 @@ Añade el módulo a `config.js` así:
     adminPort: 5003,
     openaiApiKey: "your-openApi-key here",
     pushoverApiKey: "your-pushover-api-key",
+    pushoverUser: "your-pushover-user-key",
     login: false,
     users: [
       { username: "admin", password: "secret", permission: "write" },
@@ -147,7 +148,7 @@ Ve a http://yourmirrorIP:5003/ #la página será accesible dentro de la misma re
 ## Notificaciones Push
 
 Si deseas usar notificaciones push sigue la guía a continuación.
-Alternativamente, puedes usar [Pushover](https://pushover.net/) proporcionando un `pushoverApiKey` en la configuración del módulo y habilitando Pushover con una clave de usuario desde la configuración del administrador.
+Alternativamente, puedes usar [Pushover](https://pushover.net/) proporcionando `pushoverApiKey` y `pushoverUser` en la configuración del módulo y habilitando Pushover en la configuración del administrador.
 
 ![cert](img/screenshot3_cert.png)
 


### PR DESCRIPTION
## Summary
- Require Pushover user key in `config.js` instead of admin portal
- Drop Pushover user field from admin UI and translations
- Document new Pushover configuration in README and readmeES

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2b3424f2c8324931a763a1b861f0a