### PR TITLE
Add forest background image for login overlay

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -564,6 +564,7 @@ module.exports = NodeHelper.create({
     app.use(bodyParser.json());
     app.use(express.static(path.join(__dirname, "public")));
     app.use("/img", express.static(path.join(__dirname, "img")));
+    app.use("/MMM-Chores/img", express.static(path.join(__dirname, "img")));
 
     const users = Array.isArray(self.config.users) ? self.config.users : [];
     if (self.config.login) {

--- a/public/admin.css
+++ b/public/admin.css
@@ -259,7 +259,10 @@ h1, h2 {
   display: flex;
   justify-content: center;
   align-items: center;
-  background: url("/img/forest.png") center/cover no-repeat;
+  background-image: url("img/forest.png");
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
   z-index: 2000;
 }
 #loginContainer .card {


### PR DESCRIPTION
## Summary
- Use `img/forest.png` as full-screen background for the login page
- Ensure image covers viewport and crops responsively on mobile

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a308d6772c83249823d89f4c8b6250