### PR TITLE
Add seasonal background selector to admin portal

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -314,6 +314,7 @@ module.exports = NodeHelper.create({
         autoUpdate: settings.autoUpdate ?? payload.autoUpdate,
         pushoverEnabled: settings.pushoverEnabled ?? payload.pushoverEnabled,
         reminderTime: settings.reminderTime ?? payload.reminderTime,
+        background: settings.background ?? payload.background,
         levelingEnabled: settings.levelingEnabled ?? (payload.leveling?.enabled !== false),
         leveling: {
           yearsToMaxLevel: settings.leveling?.yearsToMaxLevel ?? payload.leveling?.yearsToMaxLevel,

--- a/public/admin.css
+++ b/public/admin.css
@@ -259,7 +259,7 @@ h1, h2 {
   display: flex;
   justify-content: center;
   align-items: center;
-  background-image: url("img/forest.png");
+  /* Background image set dynamically via JavaScript */
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;

--- a/public/admin.html
+++ b/public/admin.html
@@ -219,6 +219,16 @@
               </select>
             </div>
             <div class="col-12 col-sm-6">
+              <label class="form-label" for="settingsBackground">Background</label>
+              <select id="settingsBackground" class="form-select">
+                <option value="">None</option>
+                <option value="forest">Autumn</option>
+                <option value="winter">Winter</option>
+                <option value="summer">Summer</option>
+                <option value="spring">Spring</option>
+              </select>
+            </div>
+            <div class="col-12 col-sm-6">
               <label class="form-label" for="settingsYears">Years to max level</label>
               <input type="number" id="settingsYears" class="form-control" />
             </div>

--- a/public/admin.js
+++ b/public/admin.js
@@ -18,6 +18,12 @@ let settingsSaved = false;
 let dateFormatting = '';
 let authToken = localStorage.getItem('choresToken') || null;
 let userPermission = 'write';
+const BACKGROUND_MAP = {
+  forest: 'forest.png',
+  winter: 'winter.png',
+  summer: 'summer.png',
+  spring: 'spring.png'
+};
 
 function authHeaders() {
   return authToken ? { 'x-auth-token': authToken } : {};
@@ -103,6 +109,21 @@ async function saveUserLanguage(lang) {
   }
 }
 
+function applyBackground(bg) {
+  const url = BACKGROUND_MAP[bg] ? `url("img/${BACKGROUND_MAP[bg]}")` : '';
+  document.body.style.backgroundImage = url;
+  document.body.style.backgroundSize = url ? 'cover' : '';
+  document.body.style.backgroundPosition = url ? 'center' : '';
+  document.body.style.backgroundRepeat = url ? 'no-repeat' : '';
+  const loginDiv = document.getElementById('loginContainer');
+  if (loginDiv) {
+    loginDiv.style.backgroundImage = url;
+    loginDiv.style.backgroundSize = url ? 'cover' : '';
+    loginDiv.style.backgroundPosition = url ? 'center' : '';
+    loginDiv.style.backgroundRepeat = url ? 'no-repeat' : '';
+  }
+}
+
 // ==========================
 // Init settings form and save handler
 // ==========================
@@ -119,6 +140,7 @@ function initSettingsForm(settings) {
   const autoUpdate = document.getElementById('settingsAutoUpdate');
   const pushoverEnable = document.getElementById('settingsPushoverEnable');
   const reminderTime = document.getElementById('settingsReminderTime');
+  const backgroundSelect = document.getElementById('settingsBackground');
   const yearsInput = document.getElementById('settingsYears');
   const perWeekInput = document.getElementById('settingsPerWeek');
   const maxLevelInput = document.getElementById('settingsMaxLevel');
@@ -132,6 +154,7 @@ function initSettingsForm(settings) {
   if (autoUpdate) autoUpdate.checked = !!settings.autoUpdate;
   if (pushoverEnable) pushoverEnable.checked = !!settings.pushoverEnabled;
   if (reminderTime) reminderTime.value = settings.reminderTime || '';
+  if (backgroundSelect) backgroundSelect.value = settings.background || '';
   if (yearsInput) yearsInput.value = settings.leveling?.yearsToMaxLevel || 3;
   if (perWeekInput) perWeekInput.value = settings.leveling?.choresPerWeekEstimate || 4;
   if (maxLevelInput) maxLevelInput.value = settings.leveling?.maxLevel || 100;
@@ -139,7 +162,7 @@ function initSettingsForm(settings) {
   settingsChanged = false;
   settingsSaved = false;
 
-  const inputs = [showPast, textSize, dateFmt, useAI, showAnalytics, levelEnable, autoUpdate, pushoverEnable, reminderTime, yearsInput, perWeekInput, maxLevelInput];
+  const inputs = [showPast, textSize, dateFmt, useAI, showAnalytics, levelEnable, autoUpdate, pushoverEnable, reminderTime, backgroundSelect, yearsInput, perWeekInput, maxLevelInput];
   inputs.forEach(el => {
     if (el) {
       el.addEventListener('input', () => { settingsChanged = true; });
@@ -160,6 +183,7 @@ function initSettingsForm(settings) {
       autoUpdate: autoUpdate.checked,
       pushoverEnabled: pushoverEnable.checked,
       reminderTime: reminderTime.value,
+      background: backgroundSelect.value,
       leveling: {
         yearsToMaxLevel: parseFloat(yearsInput.value) || 3,
         choresPerWeekEstimate: parseFloat(perWeekInput.value) || 4,
@@ -230,6 +254,15 @@ function setLanguage(lang) {
   if (pushoverEnableLbl) pushoverEnableLbl.textContent = t.pushoverEnabledLabel || 'Enable Pushover';
   const reminderTimeLbl = document.querySelector("label[for='settingsReminderTime']");
   if (reminderTimeLbl) reminderTimeLbl.textContent = t.reminderTimeLabel || 'Reminder time';
+  const bgLbl = document.querySelector("label[for='settingsBackground']");
+  if (bgLbl) bgLbl.textContent = t.backgroundLabel || 'Background';
+  const bgSelect = document.getElementById('settingsBackground');
+  if (bgSelect && t.backgroundOptions) {
+    Array.from(bgSelect.options).forEach(opt => {
+      const key = opt.value || 'none';
+      if (t.backgroundOptions[key]) opt.textContent = t.backgroundOptions[key];
+    });
+  }
   const yearsLbl = document.querySelector("label[for='settingsYears']");
   if (yearsLbl) yearsLbl.textContent = t.yearsToMaxLabel;
   const perWeekLbl = document.querySelector("label[for='settingsPerWeek']");
@@ -329,6 +362,9 @@ async function applySettings(newSettings) {
   }
   if (newSettings.dateFormatting !== undefined) {
     dateFormatting = newSettings.dateFormatting;
+  }
+  if (newSettings.background !== undefined) {
+    applyBackground(newSettings.background);
   }
   await fetchPeople();
   await fetchTasks();
@@ -1150,6 +1186,7 @@ async function initApp() {
     currentLang = localStorage.getItem("mmm-chores-lang") || 'en';
   }
   dateFormatting = userSettings.dateFormatting || '';
+  applyBackground(userSettings.background);
 
   const selector = document.createElement("select");
   selector.className = "language-select";

--- a/public/lang.js
+++ b/public/lang.js
@@ -63,7 +63,15 @@ const LANGUAGES = {
     choresPerWeekLabel: "Chores per week estimate",
     maxLevelLabel: "Max level",
     pushoverEnabledLabel: "Enable Pushover",
-    reminderTimeLabel: "Reminder time"
+    reminderTimeLabel: "Reminder time",
+    backgroundLabel: "Background",
+    backgroundOptions: {
+      none: "None",
+      forest: "Autumn",
+      winter: "Winter",
+      summer: "Summer",
+      spring: "Spring"
+    }
   },
   sv: {
     title: "MMM-Chores Admin  ",
@@ -129,7 +137,15 @@ const LANGUAGES = {
     choresPerWeekLabel: "Sysslor per vecka",
     maxLevelLabel: "Maxnivå",
     pushoverEnabledLabel: "Aktivera Pushover",
-    reminderTimeLabel: "Påminnelsetid"
+    reminderTimeLabel: "Påminnelsetid",
+    backgroundLabel: "Bakgrund",
+    backgroundOptions: {
+      none: "Ingen",
+      forest: "Höst",
+      winter: "Vinter",
+      summer: "Sommar",
+      spring: "Vår"
+    }
   },
   fr: {
     title: "MMM-Chores Admin  ",
@@ -195,7 +211,15 @@ const LANGUAGES = {
     choresPerWeekLabel: "Corvées par semaine",
     maxLevelLabel: "Niveau maximum",
     pushoverEnabledLabel: "Activer Pushover",
-    reminderTimeLabel: "Heure de rappel"
+    reminderTimeLabel: "Heure de rappel",
+    backgroundLabel: "Arrière-plan",
+    backgroundOptions: {
+      none: "Aucun",
+      forest: "Automne",
+      winter: "Hiver",
+      summer: "Été",
+      spring: "Printemps"
+    }
   },
   es: {
     title: "MMM-Chores Admin  ",
@@ -261,7 +285,15 @@ const LANGUAGES = {
     choresPerWeekLabel: "Tareas por semana",
     maxLevelLabel: "Nivel máximo",
     pushoverEnabledLabel: "Habilitar Pushover",
-    reminderTimeLabel: "Hora del recordatorio"
+    reminderTimeLabel: "Hora del recordatorio",
+    backgroundLabel: "Fondo",
+    backgroundOptions: {
+      none: "Ninguno",
+      forest: "Otoño",
+      winter: "Invierno",
+      summer: "Verano",
+      spring: "Primavera"
+    }
   },
   de: {
     title: "MMM-Chores Admin  ",
@@ -327,7 +359,15 @@ const LANGUAGES = {
     choresPerWeekLabel: "Aufgaben pro Woche",
     maxLevelLabel: "Max-Level",
     pushoverEnabledLabel: "Pushover aktivieren",
-    reminderTimeLabel: "Erinnerungszeit"
+    reminderTimeLabel: "Erinnerungszeit",
+    backgroundLabel: "Hintergrund",
+    backgroundOptions: {
+      none: "Keiner",
+      forest: "Herbst",
+      winter: "Winter",
+      summer: "Sommer",
+      spring: "Frühling"
+    }
   },
   it: {
     title: "MMM-Chores Admin  ",
@@ -393,7 +433,15 @@ const LANGUAGES = {
     choresPerWeekLabel: "Compiti per settimana",
     maxLevelLabel: "Livello massimo",
     pushoverEnabledLabel: "Abilita Pushover",
-    reminderTimeLabel: "Ora del promemoria"
+    reminderTimeLabel: "Ora del promemoria",
+    backgroundLabel: "Sfondo",
+    backgroundOptions: {
+      none: "Nessuno",
+      forest: "Autunno",
+      winter: "Inverno",
+      summer: "Estate",
+      spring: "Primavera"
+    }
   },
   nl: {
     title: "MMM-Chores Admin  ",
@@ -459,7 +507,15 @@ const LANGUAGES = {
     choresPerWeekLabel: "Klussen per week",
     maxLevelLabel: "Max level",
     pushoverEnabledLabel: "Pushover inschakelen",
-    reminderTimeLabel: "Herinneringstijd"
+    reminderTimeLabel: "Herinneringstijd",
+    backgroundLabel: "Achtergrond",
+    backgroundOptions: {
+      none: "Geen",
+      forest: "Herfst",
+      winter: "Winter",
+      summer: "Zomer",
+      spring: "Lente"
+    }
   },
   pl: {
     title: "MMM-Chores Admin  ",
@@ -525,7 +581,15 @@ const LANGUAGES = {
     choresPerWeekLabel: "Zadania na tydzień",
     maxLevelLabel: "Maks. poziom",
     pushoverEnabledLabel: "Włącz Pushover",
-    reminderTimeLabel: "Czas przypomnienia"
+    reminderTimeLabel: "Czas przypomnienia",
+    backgroundLabel: "Tło",
+    backgroundOptions: {
+      none: "Brak",
+      forest: "Jesień",
+      winter: "Zima",
+      summer: "Lato",
+      spring: "Wiosna"
+    }
   },
   zh: {
     title: "MMM-Chores 管理  ",
@@ -591,7 +655,15 @@ const LANGUAGES = {
     choresPerWeekLabel: "每周任务数预估",
     maxLevelLabel: "最高等级",
     pushoverEnabledLabel: "启用 Pushover",
-    reminderTimeLabel: "提醒时间"
+    reminderTimeLabel: "提醒时间",
+    backgroundLabel: "背景",
+    backgroundOptions: {
+      none: "无",
+      forest: "秋天",
+      winter: "冬天",
+      summer: "夏天",
+      spring: "春天"
+    }
   },
   ar: {
     title: "إدارة MMM-Chores  ",
@@ -657,6 +729,14 @@ const LANGUAGES = {
     choresPerWeekLabel: "عدد المهام أسبوعيًا",
     maxLevelLabel: "أقصى مستوى",
     pushoverEnabledLabel: "تفعيل Pushover",
-    reminderTimeLabel: "وقت التذكير"
+    reminderTimeLabel: "وقت التذكير",
+    backgroundLabel: "الخلفية",
+    backgroundOptions: {
+      none: "لا شيء",
+      forest: "الخريف",
+      winter: "الشتاء",
+      summer: "الصيف",
+      spring: "الربيع"
+    }
   }
 };


### PR DESCRIPTION
## Summary
- add settings dropdown to choose seasonal admin backgrounds
- apply selected image across login and portal views
- persist background choice server-side with translations for all locales

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a322cf06d883249fa6eba0cd71ae29