### PR TITLE
Limit Pushover reminders to overdue tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm install
 Most settings are now editable in the admin portal via the cogwheel **Settings** button.
 An additional option **Enable autoupdate** can pull the latest changes via `git pull` and reload the module automatically and Autoupdates run once per day at **04:00** local time.
 Pushover notifications can be toggled from the admin portal, while the `pushoverApiKey` and `pushoverUser` must be defined in your MagicMirror `config.js`.
-You can also specify a daily reminder time in the admin settings to receive a Pushover message listing unfinished tasks.
+You can also specify a daily reminder time in the admin settings to receive a Pushover message listing unfinished tasks due today or earlier.
 Add the module to `config.js` like so:
 ```js
 {

--- a/node_helper.js
+++ b/node_helper.js
@@ -88,7 +88,10 @@ function scheduleReminder(self) {
   Log.log(`Pushover reminder scheduled for ${next.toString()}`);
   reminderTimer = setTimeout(() => {
     reminderTimer = null;
-    const unfinished = tasks.filter(t => !t.done && !t.deleted);
+    const todayStr = getLocalISO(new Date()).slice(0, 10);
+    const unfinished = tasks.filter(
+      t => !t.done && !t.deleted && t.date && t.date <= todayStr
+    );
     if (unfinished.length) {
       const list = unfinished.map(t => `• ${t.name}`).join("\n");
       sendPushover(self.config, settings, `Uncompleted tasks:\n${list}`);

--- a/readmeES.md
+++ b/readmeES.md
@@ -43,6 +43,7 @@ npm install
 La mayoría de los ajustes ahora se pueden editar en el portal de administración mediante el botón de engranaje **Settings**.
 Una opción adicional **Enable autoupdate** puede obtener los últimos cambios mediante `git pull` y recargar el módulo automáticamente. Las actualizaciones automáticas se ejecutan una vez al día a las **04:00** hora local.
 Las notificaciones de Pushover se pueden activar o desactivar desde el portal de administración, mientras que `pushoverApiKey` y `pushoverUser` deben definirse en tu `config.js` de MagicMirror.
+También puedes especificar una hora de recordatorio diaria en la configuración del administrador para recibir un mensaje de Pushover con las tareas sin completar vencidas hoy o antes.
 Añade el módulo a `config.js` así:
 ```js
 {


### PR DESCRIPTION
## Summary
- Filter Pushover daily reminders to include only incomplete, non-deleted tasks whose date is today or earlier.
- Document updated behavior for reminder time in English and Spanish READMEs.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a35c50fb1083249aea80bb8ef7b5d4