### PR TITLE
Adjust task row layout for dynamic assignee width

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -513,13 +513,16 @@ function renderTasks() {
     return;
   }
 
+  const longestNameLen = peopleCache.reduce((m, p) => Math.max(m, p.name.length), 0);
+  const selectWidth = `${longestNameLen + 2}ch`;
+
   for (const task of tasksCache.filter(t => !t.deleted)) {
     const li = document.createElement("li");
-    li.className = "list-group-item d-flex justify-content-between align-items-center";
+    li.className = "list-group-item d-flex align-items-center";
     li.dataset.id = task.id;
 
     const left = document.createElement("div");
-    left.className = "d-flex align-items-center";
+    left.className = "d-flex align-items-center flex-grow-1";
 
     const chk = document.createElement("input");
     chk.type = "checkbox";
@@ -555,6 +558,8 @@ function renderTasks() {
     }
 
   const span = document.createElement("span");
+  span.classList.add("flex-grow-1");
+  span.style.minWidth = "8ch";
   const formatted = formatDate(task.date);
   span.innerHTML = `<strong>${task.name}</strong>`;
   if (formatted) {
@@ -570,7 +575,8 @@ function renderTasks() {
     left.appendChild(span);
 
     const select = document.createElement("select");
-    select.className = "form-select mx-3";
+    select.className = "form-select ms-auto me-3 flex-shrink-0";
+    select.style.width = selectWidth;
     select.add(new Option(LANGUAGES[currentLang].unassigned, ""));
     peopleCache.forEach(p => {
       const opt = new Option(p.name, p.id);


### PR DESCRIPTION
## Summary
- Let task list compute longest assignee name and size dropdowns accordingly
- Allow task text to grow and only wrap after dropdown shrinks to name length
- Prevent task name area from shrinking below 8 characters

## Testing
- `node --check public/admin.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4037bb9008324aede77509839b1bf