### PR TITLE
Fix list group border radius in card containers

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -140,6 +140,23 @@ h1, h2 {
   background: var(--list-hover);
 }
 
+/* Fix border-radius for list items inside card-shadow to prevent sharp corners */
+.card-shadow .list-group-item {
+  border-radius: 0;
+}
+.card-shadow .list-group-item:first-child {
+  border-top-left-radius: calc(1rem - 1px);
+  border-top-right-radius: calc(1rem - 1px);
+}
+.card-shadow .list-group-item:last-child {
+  border-bottom-left-radius: calc(1rem - 1px);
+  border-bottom-right-radius: calc(1rem - 1px);
+}
+/* Handle case where there's only one list item */
+.card-shadow .list-group-item:only-child {
+  border-radius: calc(1rem - 1px);
+}
+
 /* Input fields */
 .form-control,
 .form-select {


### PR DESCRIPTION
## Summary
- Ensure list items inside `.card-shadow` cards inherit rounded corners
- Handle first, last, and single list items for seamless radius

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5764bab3c83248dc7842c5d31fa07