### PR TITLE
Hide leveling options when leveling disabled

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -270,15 +270,15 @@
                 <option value="spring.png">Spring</option>
               </select>
             </div>
-            <div class="col-12 col-sm-6">
+            <div class="col-12 col-sm-6 leveling-settings">
               <label class="form-label" for="settingsYears">Years to max level</label>
               <input type="number" id="settingsYears" class="form-control" />
             </div>
-            <div class="col-12 col-sm-6">
+            <div class="col-12 col-sm-6 leveling-settings">
               <label class="form-label" for="settingsPerWeek">Chores per week estimate</label>
               <input type="number" id="settingsPerWeek" class="form-control" />
             </div>
-            <div class="col-12 col-sm-6">
+            <div class="col-12 col-sm-6 leveling-settings">
               <label class="form-label" for="settingsMaxLevel">Max level</label>
               <input type="number" id="settingsMaxLevel" class="form-control" />
             </div>

--- a/public/admin.js
+++ b/public/admin.js
@@ -166,6 +166,16 @@ function initSettingsForm(settings) {
     if (maxLevelInput) maxLevelInput.value = settings.leveling?.maxLevel || 100;
     if (backgroundSelect) backgroundSelect.value = settings.background || 'forest.png';
 
+  const levelingFields = document.querySelectorAll('.leveling-settings');
+  const toggleLevelingFields = () => {
+    const show = levelEnable && levelEnable.checked;
+    levelingFields.forEach(el => el.classList.toggle('d-none', !show));
+  };
+  if (levelEnable) {
+    levelEnable.addEventListener('change', toggleLevelingFields);
+  }
+  toggleLevelingFields();
+
   settingsChanged = false;
   settingsSaved = false;
 


### PR DESCRIPTION
## Summary
- hide leveling-specific settings when leveling is disabled
- restore fields when the Enable leveling checkbox is checked

## Testing
- `node --check public/admin.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a58c3028ec8324b2f7d5a38c5ff388