### PR TITLE
Enable login submission via Enter key

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -14,17 +14,19 @@
 <body>
   <div id="loginContainer" class="login-overlay" style="display:none;">
     <div class="card card-shadow p-4">
-      <h2 class="text-center mb-4">Login</h2>
-      <div class="mb-3">
-        <label for="loginUser" class="form-label">Username</label>
-        <input type="text" id="loginUser" class="form-control" placeholder="Username" />
-      </div>
-      <div class="mb-3">
-        <label for="loginPass" class="form-label">Password</label>
-        <input type="password" id="loginPass" class="form-control" placeholder="Password" />
-      </div>
-      <button id="loginBtn" class="btn btn-primary w-100">Login</button>
-      <div id="loginError" class="text-danger mt-2"></div>
+      <form id="loginForm">
+        <h2 class="text-center mb-4">Login</h2>
+        <div class="mb-3">
+          <label for="loginUser" class="form-label">Username</label>
+          <input type="text" id="loginUser" class="form-control" placeholder="Username" />
+        </div>
+        <div class="mb-3">
+          <label for="loginPass" class="form-label">Password</label>
+          <input type="password" id="loginPass" class="form-control" placeholder="Password" />
+        </div>
+        <button type="submit" id="loginBtn" class="btn btn-primary w-100">Login</button>
+        <div id="loginError" class="text-danger mt-2"></div>
+      </form>
     </div>
   </div>
   <div id="app" style="display:none;">

--- a/public/admin.js
+++ b/public/admin.js
@@ -75,9 +75,10 @@ async function checkLogin() {
     return;
   }
   if (loginDiv) loginDiv.style.display = '';
-  const btn = document.getElementById('loginBtn');
-  if (btn) {
-    btn.onclick = async () => {
+  const form = document.getElementById('loginForm');
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
       const username = document.getElementById('loginUser').value;
       const password = document.getElementById('loginPass').value;
       const resp = await fetch('/api/login', {
@@ -97,7 +98,7 @@ async function checkLogin() {
         const err = document.getElementById('loginError');
         if (err) err.textContent = out.error || LANGUAGES[currentLang].loginError || 'Login failed';
       }
-    };
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- Wrap admin login fields in a form and handle submission in JS
- Trigger login on Enter key press by listening to form submission

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a58e26d8b88324b11aff3037b61744