### PR TITLE
feat: localize reminder time format

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -242,6 +242,14 @@ function setLanguage(lang) {
   localStorage.setItem("mmm-chores-lang", lang);
   document.documentElement.setAttribute('lang', lang);
 
+  // Update reminder time input to reflect chosen language so the browser
+  // renders the appropriate 12h/24h clock. For English we default to the
+  // 12h "en-US" locale, otherwise we use the selected language directly.
+  const reminderInput = document.getElementById('settingsReminderTime');
+  if (reminderInput) {
+    reminderInput.setAttribute('lang', lang === 'en' ? 'en-US' : lang);
+  }
+
   const t = LANGUAGES[lang];
 
   localizedMonths = Array.from({ length: 12 }, (_, i) =>


### PR DESCRIPTION
## Summary
- ensure reminder time input switches between 12h and 24h clock based on selected language

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5c2c6aa388324bda06d19e4a3994b