### PR TITLE
Fix footer placement on admin page

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -291,8 +291,10 @@
         </div>
       </div>
     </div>
+    </div>
+    </div>
     <footer class="text-center py-3 small text-muted" id="footerText">
-      MMM-Chores Built by Pierre Gode
+      Built with Bootstrap & Chart.js • MMM-Chores by Pierre Gode
     </footer>
   </div>
 


### PR DESCRIPTION
## Summary
- Add missing closing tags so settings modal is properly terminated
- Move footer outside settings modal and update its default text

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5cebdef18832492a27df0f8bdc96c