### PR TITLE
Add session timeout and unauthorized response handling

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -28,7 +28,15 @@ function authHeaders() {
 
 function authFetch(url, options = {}) {
   options.headers = Object.assign({}, authHeaders(), options.headers || {});
-  return fetch(url, options);
+  return fetch(url, options).then(res => {
+    if (res.status === 401) {
+      authToken = null;
+      localStorage.removeItem('choresToken');
+      checkLogin();
+      throw new Error('Unauthorized');
+    }
+    return res;
+  });
 }
 
 function setBackground(image) {


### PR DESCRIPTION
## Summary
- expire login sessions after 24 hours and refresh on activity
- remove expired sessions and internal token never expires
- auto-redirect UI to login when a request returns 401

## Testing
- `node --check node_helper.js`
- `node --check public/admin.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6052fcdf08324b322a9f4e0e229fb