### PR TITLE
Fix add-person button height mismatch

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -182,6 +182,11 @@ h1, h2 {
   padding: 0;
 }
 
+/* In input groups, allow icon buttons to match the input height */
+.input-group .btn-icon {
+  height: auto;
+}
+
 /* Completed task style */
 .task-done {
   text-decoration: line-through;


### PR DESCRIPTION
## Summary
- ensure icon buttons inside admin input groups match the text field height

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a61c9513fc8324ae661cbbf336e26e