### PR TITLE
Handle missing Pushover config and toggle reminder UI

### DIFF
--- a/MMM-Chores.js
+++ b/MMM-Chores.js
@@ -130,6 +130,13 @@ Module.register("MMM-Chores", {
       }
       this.updateDom();
     }
+    if (notification === "PUSHOVER_CONFIG_ERROR") {
+      this.sendNotification("SHOW_ALERT", {
+        type: "notification",
+        title: "MMM-Chores",
+        message: payload || "Please set pushoverApiKey and pushoverUser in config.js to use Pushover notifications."
+      });
+    }
   },
 
   shouldShowTask(task) {

--- a/public/admin.js
+++ b/public/admin.js
@@ -156,6 +156,7 @@ function initSettingsForm(settings) {
     const autoUpdate = document.getElementById('settingsAutoUpdate');
     const pushoverEnable = document.getElementById('settingsPushoverEnable');
     const reminderTime = document.getElementById('settingsReminderTime');
+    const reminderContainer = reminderTime ? reminderTime.parentElement : null;
     const yearsInput = document.getElementById('settingsYears');
     const perWeekInput = document.getElementById('settingsPerWeek');
     const maxLevelInput = document.getElementById('settingsMaxLevel');
@@ -184,6 +185,15 @@ function initSettingsForm(settings) {
     levelEnable.addEventListener('change', toggleLevelingFields);
   }
   toggleLevelingFields();
+
+  const toggleReminderField = () => {
+    const show = pushoverEnable && pushoverEnable.checked;
+    if (reminderContainer) reminderContainer.classList.toggle('d-none', !show);
+  };
+  if (pushoverEnable) {
+    pushoverEnable.addEventListener('change', toggleReminderField);
+  }
+  toggleReminderField();
 
   settingsChanged = false;
   settingsSaved = false;
@@ -227,6 +237,9 @@ function initSettingsForm(settings) {
         await applySettings(data.settings || payload);
         const instance = bootstrap.Modal.getInstance(document.getElementById('settingsModal'));
         if (instance) instance.hide();
+      } else {
+        const out = await res.json().catch(() => ({}));
+        alert(out.error || 'Failed saving settings');
       }
     } catch (err) {
       console.error('Failed saving settings', err);


### PR DESCRIPTION
## Summary
- Hide Pushover reminder settings when notifications are disabled
- Alert users when Pushover API credentials are missing
- Validate Pushover configuration before saving settings

## Testing
- `node --check node_helper.js`
- `node --check MMM-Chores.js`
- `node --check public/admin.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6204322bc83248f454ddd9c736860