### PR TITLE
Add daily recurring task option

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -298,7 +298,9 @@ function broadcastTasks(helper) {
 
 function getNextDate(dateStr, recurring) {
   const d = new Date(dateStr);
-  if (recurring === "weekly") {
+  if (recurring === "daily") {
+    d.setDate(d.getDate() + 1);
+  } else if (recurring === "weekly") {
     d.setDate(d.getDate() + 7);
   } else if (recurring === "monthly") {
     d.setMonth(d.getMonth() + 1);

--- a/public/admin.html
+++ b/public/admin.html
@@ -110,13 +110,14 @@
                     </select>
                   </div>
                   <div class="col-sm-auto">
-                    <select id="taskRecurring" class="form-select">
-                      <option value="">One time</option>
-                      <option value="weekly">Weekly</option>
-                      <option value="monthly">Monthly</option>
-                      <option value="yearly">Yearly</option>
-                    </select>
-                  </div>
+        <select id="taskRecurring" class="form-select">
+          <option value="">One time</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+          <option value="yearly">Yearly</option>
+        </select>
+      </div>
                   <div class="col-sm-auto d-flex gap-2">
                     <button class="btn btn-primary" type="submit" id="btnAddTask">
                       <i class="bi bi-plus-lg me-1"></i>Add

--- a/public/lang.js
+++ b/public/lang.js
@@ -12,6 +12,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Task name…",
     taskRecurring: {
       none: "One time",
+      daily: "Daily",
       weekly: "Weekly",
       monthly: "Monthly",
       yearly: "Yearly"
@@ -106,6 +107,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Uppgiftsnamn…",
     taskRecurring: {
       none: "Engång",
+      daily: "Dagligen",
       weekly: "Veckovis",
       monthly: "Månadsvis",
       yearly: "Årligen"
@@ -200,6 +202,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Nom de la tâche…",
     taskRecurring: {
       none: "Unique",
+      daily: "Quotidien",
       weekly: "Hebdomadaire",
       monthly: "Mensuel",
       yearly: "Annuel"
@@ -294,6 +297,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Nombre de tarea…",
     taskRecurring: {
       none: "Una vez",
+      daily: "Diario",
       weekly: "Semanal",
       monthly: "Mensual",
       yearly: "Anual"
@@ -388,6 +392,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Aufgabenname…",
     taskRecurring: {
       none: "Einmalig",
+      daily: "Täglich",
       weekly: "Wöchentlich",
       monthly: "Monatlich",
       yearly: "Jährlich"
@@ -482,6 +487,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Nome del compito…",
     taskRecurring: {
       none: "Una tantum",
+      daily: "Giornaliero",
       weekly: "Settimanale",
       monthly: "Mensile",
       yearly: "Annuale"
@@ -576,6 +582,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Taaknaam…",
     taskRecurring: {
       none: "Eenmalig",
+      daily: "Dagelijks",
       weekly: "Wekelijks",
       monthly: "Maandelijks",
       yearly: "Jaarlijks"
@@ -670,6 +677,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Nazwa zadania…",
     taskRecurring: {
       none: "Jednorazowe",
+      daily: "Codziennie",
       weekly: "Tygodniowo",
       monthly: "Miesięcznie",
       yearly: "Rocznie"
@@ -764,6 +772,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "任务名称…",
     taskRecurring: {
       none: "一次性",
+      daily: "每日",
       weekly: "每周",
       monthly: "每月",
       yearly: "每年"
@@ -858,6 +867,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "اسم المهمة…",
     taskRecurring: {
       none: "مرة واحدة",
+      daily: "يومي",
       weekly: "أسبوعي",
       monthly: "شهري",
       yearly: "سنوي"


### PR DESCRIPTION
## Summary
- allow chores to repeat daily on server side
- expose daily recurrence in admin interface and translations

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac0d2169108324ac5d1a80646b0aae