### PR TITLE
Add daily recurring chore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/J3J2EARPK)
 
-It provides an admin interface where you can add, edit, and delete tasks. You can also set due dates and assign tasks to different persons. The module displays the tasks on your MagicMirror, allowing you to keep track of your household chores at a glance.
+It provides an admin interface where you can add, edit, and delete tasks. You can also set due dates and assign tasks to different persons. Tasks may be one-time or recur daily, weekly, monthly, or yearly. The module displays the tasks on your MagicMirror, allowing you to keep track of your household chores at a glance.
 
 The data is stored in `data.json` so it persists across restarts.
 Use the drag handle ("burger" icon) to reorder tasks in the admin UI. The

--- a/node_helper.js
+++ b/node_helper.js
@@ -298,7 +298,9 @@ function broadcastTasks(helper) {
 
 function getNextDate(dateStr, recurring) {
   const d = new Date(dateStr);
-  if (recurring === "weekly") {
+  if (recurring === "daily") {
+    d.setDate(d.getDate() + 1);
+  } else if (recurring === "weekly") {
     d.setDate(d.getDate() + 7);
   } else if (recurring === "monthly") {
     d.setMonth(d.getMonth() + 1);

--- a/public/admin.html
+++ b/public/admin.html
@@ -112,6 +112,7 @@
                   <div class="col-sm-auto">
                     <select id="taskRecurring" class="form-select">
                       <option value="">One time</option>
+                      <option value="daily">Daily</option>
                       <option value="weekly">Weekly</option>
                       <option value="monthly">Monthly</option>
                       <option value="yearly">Yearly</option>

--- a/public/lang.js
+++ b/public/lang.js
@@ -12,6 +12,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Task name…",
     taskRecurring: {
       none: "One time",
+      daily: "Daily",
       weekly: "Weekly",
       monthly: "Monthly",
       yearly: "Yearly"
@@ -106,6 +107,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Uppgiftsnamn…",
     taskRecurring: {
       none: "Engång",
+      daily: "Dagligen",
       weekly: "Veckovis",
       monthly: "Månadsvis",
       yearly: "Årligen"
@@ -200,6 +202,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Nom de la tâche…",
     taskRecurring: {
       none: "Unique",
+      daily: "Quotidien",
       weekly: "Hebdomadaire",
       monthly: "Mensuel",
       yearly: "Annuel"
@@ -294,6 +297,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Nombre de tarea…",
     taskRecurring: {
       none: "Una vez",
+      daily: "Diario",
       weekly: "Semanal",
       monthly: "Mensual",
       yearly: "Anual"
@@ -388,6 +392,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Aufgabenname…",
     taskRecurring: {
       none: "Einmalig",
+      daily: "Täglich",
       weekly: "Wöchentlich",
       monthly: "Monatlich",
       yearly: "Jährlich"
@@ -482,6 +487,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Nome del compito…",
     taskRecurring: {
       none: "Una tantum",
+      daily: "Giornaliero",
       weekly: "Settimanale",
       monthly: "Mensile",
       yearly: "Annuale"
@@ -576,6 +582,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Taaknaam…",
     taskRecurring: {
       none: "Eenmalig",
+      daily: "Dagelijks",
       weekly: "Wekelijks",
       monthly: "Maandelijks",
       yearly: "Jaarlijks"
@@ -670,6 +677,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "Nazwa zadania…",
     taskRecurring: {
       none: "Jednorazowe",
+      daily: "Codziennie",
       weekly: "Tygodniowo",
       monthly: "Miesięcznie",
       yearly: "Rocznie"
@@ -764,6 +772,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "任务名称…",
     taskRecurring: {
       none: "一次性",
+      daily: "每日",
       weekly: "每周",
       monthly: "每月",
       yearly: "每年"
@@ -858,6 +867,7 @@ const LANGUAGES = {
     taskNamePlaceholder: "اسم المهمة…",
     taskRecurring: {
       none: "مرة واحدة",
+      daily: "يومي",
       weekly: "أسبوعي",
       monthly: "شهري",
       yearly: "سنوي"

--- a/readmeES.md
+++ b/readmeES.md
@@ -4,7 +4,7 @@
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/J3J2EARPK)
 
-Proporciona una interfaz de administración donde puedes añadir, editar y eliminar tareas. También puedes establecer fechas límite y asignar tareas a diferentes personas. El módulo muestra las tareas en tu MagicMirror, permitiéndote llevar un seguimiento de las tareas domésticas de un vistazo.
+Proporciona una interfaz de administración donde puedes añadir, editar y eliminar tareas. También puedes establecer fechas límite y asignar tareas a diferentes personas. Las tareas pueden ser únicas o repetirse diariamente, semanalmente, mensualmente o anualmente. El módulo muestra las tareas en tu MagicMirror, permitiéndote llevar un seguimiento de las tareas domésticas de un vistazo.
 
 Los datos se almacenan en `data.json` para que persistan entre reinicios.
 Usa el asa de arrastre (icono de "hamburguesa") para reordenar las tareas en la interfaz de administración. El


### PR DESCRIPTION
## Summary
- allow tasks to recur daily in the admin UI
- support `daily` recurrence in backend scheduling
- document that chores can recur daily, weekly, monthly or yearly

## Testing
- `node --check node_helper.js`
- `node --check public/lang.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac0fb303a083249f24454d578b5eb2